### PR TITLE
[base] gitの最新版をインストールできるようにする

### DIFF
--- a/site-cookbooks/base/recipes/default.rb
+++ b/site-cookbooks/base/recipes/default.rb
@@ -75,10 +75,18 @@ package "zsh" do
   not_if "which zsh"
 end
 
+apt_repository "git" do
+  uri            "http://ppa.launchpad.net/git-core/ppa/ubuntu"
+  distribution   node['lsb']['codename']
+  components     ['main']
+  keyserver 'keyserver.ubuntu.com'
+  key 'E1DF1F24'
+end
+
 package "git-core" do
   action :install
 
-  not_if "which git"
+  options "--force-yes"
 end
 
 cookbook_file "/usr/share/git-core/templates/hooks/pre-commit" do


### PR DESCRIPTION
[Git stable releases](https://launchpad.net/~git-core/+archive/ppa) からインストールする。
