### PR TITLE
git の pre-push hook 用スクリプトをデプロイする

### DIFF
--- a/site-cookbooks/base/recipes/default.rb
+++ b/site-cookbooks/base/recipes/default.rb
@@ -89,6 +89,16 @@ package "git-core" do
   options "--force-yes"
 end
 
+remote_file "/usr/share/git-core/templates/hooks/pre-push" do
+  source "https://gist.github.com/kazu634/8267388/raw/e9202cd4c29a66723c88d2be05f3cd19413d2137/pre-push"
+
+  owner "root"
+  group "root"
+  mode 0755
+
+  not_if "test -e /usr/share/git-core/templates/hooks/pre-push"
+end
+
 cookbook_file "/usr/share/git-core/templates/hooks/pre-commit" do
   action   :create
 


### PR DESCRIPTION
[Gitのpre-push hook用スクリプト。git-nowコマンドと一緒に使うことを想定しています。](https://gist.github.com/kazu634/8267388) を `/usr/share/git-core/templates/hooks/` へデプロイする。
