### PR TITLE
ruby_setupのcookbook_fileの部分で失敗する

### DIFF
--- a/site-cookbooks/ruby/providers/setup.rb
+++ b/site-cookbooks/ruby/providers/setup.rb
@@ -49,11 +49,12 @@ action :install do
     end
 
     cookbook_file "#{home}/.rbenv/default-gems" do
-      source "default-gems"
+      source     "default-gems"
+      cookbook   "ruby"
 
-      owner  user
-      group  group
-      mode   0644
+      owner      user
+      group      group
+      mode       0644
     end
 
     script "install ruby" do


### PR DESCRIPTION
This commit refs #34.

```
  * cookbook_file[/var/lib/jenkins/.rbenv/default-gems] action create
    - create new file /var/lib/jenkins/.rbenv/default-gems
================================================================================
Error executing action `create` on resource 'cookbook_file[/var/lib/jenkins/.rbenv/default-gems]'
================================================================================


Chef::Exceptions::FileNotFound
------------------------------
Cookbook 'jenkins' (0.1.0) does not contain a file at any of these locations:
  files/ubuntu-12.04/default-gems
  files/ubuntu/default-gems
  files/default/default-gems

This cookbook _does_ contain: ['/home/kazu634/chef-solo/cookbooks-2/jenkins/files/default/config','/home/kazu634/chef-solo/cookbooks-2/jenkins/files/default/jenkins','/home/kazu634/chef-solo/cookbooks-2/jenkins/files/default/gitconfig']


Resource Declaration:
---------------------
# In /home/kazu634/chef-solo/cookbooks-2/ruby/providers/setup.rb

 51:     cookbook_file "#{home}/.rbenv/default-gems" do
 52:       source "default-gems"
 53:
 54:       owner  user
 55:       group  group
 56:       mode   0644
 57:     end
 58:



Compiled Resource:
------------------
# Declared in /home/kazu634/chef-solo/cookbooks-2/ruby/providers/setup.rb:51:in `block in class_from_file'

cookbook_file("/var/lib/jenkins/.rbenv/default-gems") do
  provider Chef::Provider::CookbookFile
  action "create"
  retries 0
  retry_delay 2
  path "/var/lib/jenkins/.rbenv/default-gems"
  backup 5
  atomic_update true
  source "default-gems"
  cookbook_name :jenkins
  recipe_name "none"
  mode 420
  owner "jenkins"
  group "nogroup"
end



Recipe: iptables::default
  * execute[rebuild-iptables] action run
    - execute /usr/sbin/rebuild-iptables

Recipe: base::default
  * service[ssh] action restart
    - restart service service[ssh]

Recipe: monit::default
  * service[monit] action reload
    - reload service service[monit]

  * script[initctl reload-configuration] action run
    - execute "bash"  "/tmp/chef-script20140225-1475-yf1udm"

Recipe: munin-node::default
  * service[munin-node] action restart
    - restart service service[munin-node]

Recipe: kazu634::default
  * script[install rcfiles] action run
    - execute "bash"  "/tmp/chef-script20140225-1475-plnqfx"

Recipe: nagios::nrpe
  * service[nagios-nrpe-server] action restart
    - restart service service[nagios-nrpe-server]

Recipe: nginx::default
  * service[nginx] action restart
    - restart service service[nginx]

Recipe: monit::default
  * service[monit] action restart
    - restart service service[monit]


Running handlers:
[2014-02-25T10:37:58+09:00] ERROR: Running exception handlers
Running handlers complete

[2014-02-25T10:37:58+09:00] ERROR: Exception handlers complete
[2014-02-25T10:37:58+09:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
Chef Client failed. 125 resources updated in 800.785598351 seconds
[2014-02-25T10:37:58+09:00] ERROR: cookbook_file[/var/lib/jenkins/.rbenv/default-gems] (jenkins::none line 51) had an error: Chef::Exceptions::FileNotFound: Cookbook 'jenkins' (0.1.0) does not contain a file at any of these locations:
  files/ubuntu-12.04/default-gems
  files/ubuntu/default-gems
  files/default/default-gems

This cookbook _does_ contain: ['/home/kazu634/chef-solo/cookbooks-2/jenkins/files/default/config','/home/kazu634/chef-solo/cookbooks-2/jenkins/files/default/jenkins','/home/kazu634/chef-solo/cookbooks-2/jenkins/files/default/gitconfig']
[2014-02-25T10:37:59+09:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
ERROR: RuntimeError: chef-solo failed. See output above.
```
