### PR TITLE
data bagを作成するときのチュートリアルをREADME.mdに追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,26 @@ That's it. Easy enough?
 You know the secret key is on /home/kazu634.
 Just copy the key to /path/to/chef.
 
+## How to manipulate an encrypted data bag
+This section illustrate how to manipulate an encrypted data bag
+
+### How to make an encrypted data bag
+
+    export EDITOR="vim -u NONE -U NONE --noplugin"
+
+    bundle exec knife solo data bag create apps app_1
+
+### How to show an encrypted data bag
+
+    export EDITOR="vim -u NONE -U NONE --noplugin"
+
+    bundle exec knife solo data bag show apps app_1
+
+### How to edit an encrypted data bag
+
+    export EDITOR="vim -u NONE -U NONE --noplugin"
+
+    bundle exec knife solo data bag edit apps app_1
+
 # Build Status
 [![Build Status](https://api.travis-ci.org/kazu634/chef.png)](https://api.travis-ci.org/kazu634/chef.png)


### PR DESCRIPTION
ここらへんを参考にする:
- [Chef Solo + Knife Solo で暗号化データバッグを使う - Qiita](http://qiita.com/labocho/items/77125e3d321ae14efbbf)
- [knife-solo_data_bagを使ってEncrypted Data Bagで暗号化したファイルを配布する - 頑張ってる途中](http://kataring.hatenablog.com/entry/2013/05/15/193430)

export EDITOR=vim するときは、これを使わないとダメみたい:

```
export EDITOR="vim -u NONE -U NONE --noplugin"
```
