### PR TITLE
nginxのworker processの数をCPUのコア数に応じて設定する

### DIFF
--- a/site-cookbooks/nginx/attributes/default.rb
+++ b/site-cookbooks/nginx/attributes/default.rb
@@ -1,1 +1,1 @@
-default['nginx']['num_of_procs']=1
+default['nginx']['num_of_procs']=`cat /proc/cpuinfo | grep processor | wc -l`.chomp


### PR DESCRIPTION
nginxのworker processの数をCPUのコア数に応じて設定する
