### PR TITLE
[sensu-custom] rabbitmqのmonit設定ファイルがおかしい

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/server_settings.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_settings.rb
@@ -14,9 +14,9 @@ include_recipe "sensu-custom::server_handlers"
 include_recipe "iptables"
 iptables_rule  "rabbitmq"
 
-%w{redis.conf rabbimq.conf}.each do |conf|
+%w{redis.conf rabbitmq.conf}.each do |conf|
   cookbook_file "/etc/monit/conf.d/#{conf}" do
-    source "redis.conf"
+    source "#{conf}"
 
     owner "root"
     group "root"


### PR DESCRIPTION
```
Recipe: monit::default
  * service[monit] action restart
================================================================================
Error executing action `restart` on resource 'service[monit]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of /etc/init.d/monit start ----
STDOUT: * Starting daemon monitor monit
   ...fail!
STDERR: /etc/monit/conf.d/rabbimq.conf:2: Error: service name conflict, redis already defined '/var/run/redis/6379/redis_6379.pid'
---- End output of /etc/init.d/monit start ----
Ran /etc/init.d/monit start returned 1
```
