### PR TITLE
github-commit-status-updaterをアンインストールする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gem 'knife-solo_data_bag'
 gem 'foodcritic', "~> 3.0.0"
 gem 'serverspec'
 gem 'ci_reporter'
-gem 'github-commit-status-updater', github: 'joker1007/github-commit-status-updater'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/joker1007/github-commit-status-updater.git
-  revision: f7f347cae54fb751183e9af22a53175e93acb4e6
-  specs:
-    github-commit-status-updater (1.0.3)
-      octokit
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -72,20 +64,19 @@ GEM
       winrm (~> 1.1.2)
     erubis (2.7.0)
     eventmachine (1.0.3)
-    excon (0.25.3)
+    excon (0.31.0)
     faraday (0.8.9)
       multipart-post (~> 1.2.0)
     ffi (1.9.3)
-    fog (1.15.0)
+    fog (1.20.0)
       builder
-      excon (~> 0.25.0)
+      excon (~> 0.31.0)
       formatador (~> 0.2.0)
       mime-types
       multi_json (~> 1.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5)
-      ruby-hmac
+      nokogiri (>= 1.5.11)
     foodcritic (3.0.3)
       erubis
       gherkin (~> 2.11.7)
@@ -109,9 +100,8 @@ GEM
     i18n (0.6.9)
     ipaddress (0.8.0)
     json (1.7.7)
-    knife-ec2 (0.6.6)
-      chef (>= 0.10.10)
-      fog (~> 1.15.0)
+    knife-ec2 (0.8.0)
+      fog (~> 1.20.0)
       knife-windows (>= 0.5.12)
     knife-solo (0.3.0)
       chef (>= 10.12)
@@ -124,7 +114,7 @@ GEM
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
-    mime-types (2.1)
+    mime-types (2.2)
     minitar (0.5.4)
     mixlib-authentication (1.3.0)
       mixlib-log
@@ -132,7 +122,7 @@ GEM
     mixlib-config (1.1.2)
     mixlib-log (1.6.0)
     mixlib-shellout (1.3.0)
-    multi_json (1.9.0)
+    multi_json (1.9.2)
     multipart-post (1.2.0)
     net-http-persistent (2.9.4)
     net-scp (1.1.2)
@@ -146,8 +136,6 @@ GEM
     nio4r (1.0.0)
     nokogiri (1.5.11)
     nori (1.1.5)
-    octokit (2.7.2)
-      sawyer (~> 0.5.2)
     ohai (6.20.0)
       ipaddress
       mixlib-cli
@@ -191,7 +179,6 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
-    ruby-hmac (0.4.0)
     rubyntlm (0.1.1)
     savon (0.9.5)
       akami (~> 1.0)
@@ -201,16 +188,13 @@ GEM
       nokogiri (>= 1.4.0)
       nori (~> 1.0)
       wasabi (~> 1.0)
-    sawyer (0.5.3)
-      addressable (~> 2.3.5)
-      faraday (~> 0.8, < 0.10)
-    serverspec (0.15.4)
+    serverspec (0.15.5)
       highline
       net-ssh
-      rspec (>= 2.13.0)
+      rspec (~> 2.13)
       specinfra (>= 0.7.1)
     solve (0.8.2)
-    specinfra (0.7.1)
+    specinfra (0.8.0)
     systemu (2.5.2)
     thor (0.18.1)
     timers (2.0.0)
@@ -242,7 +226,6 @@ DEPENDENCIES
   chef
   ci_reporter
   foodcritic (~> 3.0.0)
-  github-commit-status-updater!
   knife-ec2
   knife-solo (~> 0.3.0.pre4)
   knife-solo_data_bag


### PR DESCRIPTION
Jenkinsプラグインで対応することとしたため、`Gemfile`から`github-commit-status-updater`を削除する
