### PR TITLE
[sensu-custom] net-ping gemのインストールをやめる

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/prerequisites.rb
+++ b/site-cookbooks/sensu-custom/recipes/prerequisites.rb
@@ -7,7 +7,7 @@
 # All rights reserved - Do Not Redistribute
 #
 
-%w{ sensu-plugin twitter net-ping }.each do |p|
+%w{ sensu-plugin twitter }.each do |p|
   gem_package p do
     action     :install
     retries    3


### PR DESCRIPTION
#51 で削除するのを忘れたため、`net-ping` gemのインストールを取りやめる。
