### PR TITLE
テストに失敗する

### DIFF
--- a/test/spec/kazu634/ssh_spec.rb
+++ b/test/spec/kazu634/ssh_spec.rb
@@ -31,5 +31,5 @@ end
 describe file('/home/kazu634/.ssh/config') do
   it { should be_file }
   it { should be_mode 664 }
-  it { should match_md5checksum '909715fcdbea44560c38f6d08b74038b' }
+  it { should match_md5checksum '4fe67db8d596501f778e82eba5861f22' }
 end


### PR DESCRIPTION
```
00:16:08.153 Failures:
00:16:08.153 
00:16:08.154   1) File "/home/kazu634/.ssh/config" should match md5checksum "909715fcdbea44560c38f6d08b74038b"
00:16:08.155      Failure/Error: it { should match_md5checksum '909715fcdbea44560c38f6d08b74038b' }
00:16:08.159        sudo md5sum /home/kazu634/.ssh/config | grep -iw -- \^909715fcdbea44560c38f6d08b74038b
00:16:08.159        
00:16:08.160        expected File "/home/kazu634/.ssh/config" to match md5checksum "909715fcdbea44560c38f6d08b74038b"
00:16:08.161      # ./spec/kazu634/ssh_spec.rb:34:in `block (2 levels) in <top (required)>'
00:16:08.161 
00:16:08.162 Finished in 12.03 seconds
```

This issue refs #56.
