### PR TITLE
[sensu-custom] sensu-serverのテストは実施しない

### DIFF
--- a/nodes/template.json.erb
+++ b/nodes/template.json.erb
@@ -1,7 +1,4 @@
 {
-  "sensu-custom":{
-      "server": true
-  },
   "run_list": [
     <% recipes.each do |recipe| %>
     "recipe[<%= recipe %>]",


### PR DESCRIPTION
`sensu-server`のテストは`rabbitmq`のインストールで失敗するため、実施しないこととする。
