### PR TITLE
Rakefileでテストデータ作成時のタスクを改良する

### DIFF
--- a/test/template.erb
+++ b/test/template.erb
@@ -13,7 +13,7 @@ hosts = [
   {
     :name  => 'test',
     :roles => %w(
-      <% tests.each do |recipe| %>
+      <% tests_local.each do |recipe| %>
         <%= recipe %>
       <% end %>),
   },


### PR DESCRIPTION
`gen_data`タスクには
1. ノードに適用するテストデータ作成
2. `serverspec`でテストする対象のspec指定

のデータを作成するが、1.と2.はほぼイコールであり、存在しないspecを指定しても無視されることがわかったため、1.と2.のロジックを統合する。
