### PR TITLE
[munin-node] ダウンロードリンクを更新する

### DIFF
--- a/site-cookbooks/munin-node/recipes/default.rb
+++ b/site-cookbooks/munin-node/recipes/default.rb
@@ -16,6 +16,8 @@ packages = %w(
   liblist-moreutils-perl
   libnet-cidr-perl
   libnet-server-perl
+  libjs-underscore
+  libjs-jquery
 )
 
 packages.each do |pkg|


### PR DESCRIPTION
ダウンロードリンクを更新する

```
================================================================================
Error executing action `create` on resource 'remote_file[/tmp/munin-common.deb]'
================================================================================


Net::HTTPServerException
------------------------
404 "Not Found"


Resource Declaration:
---------------------
# In /home/kazu634/chef-solo/cookbooks-2/munin-node/recipes/default.rb

 43:   remote_file dir.dup do
 44:     source pkg.dup
 45:
 46:     not_if "which munin-node"
 47:   end
 48: end



Compiled Resource:
------------------
# Declared in /home/kazu634/chef-solo/cookbooks-2/munin-node/recipes/default.rb:43:in `block in from_file'

remote_file("/tmp/munin-common.deb") do
  provider Chef::Provider::RemoteFile
  action "create"
  retries 0
  retry_delay 2
  path "/tmp/munin-common.deb"
  backup 5
  atomic_update true
  source ["http://ftp.jp.debian.org/debian/pool/main/m/munin/munin-common_2.1.5-1_all.deb"]
  use_etag true
  use_last_modified true
  cookbook_name :"munin-node"
  recipe_name "default"
  not_if "which munin-node"
end



Recipe: iptables::default
  * execute[rebuild-iptables] action run
    - execute /usr/sbin/rebuild-iptables

Recipe: base::ssh
  * service[ssh] action restart
    - restart service service[ssh]

Recipe: base::ntp
  * service[ntp] action restart
    - restart service service[ntp]

Recipe: monit::default
  * service[monit] action reload
    - reload service service[monit]

  * script[initctl reload-configuration] action run
    - execute "bash"  "/tmp/chef-script20140601-1471-1t1wixh"


Running handlers:
[2014-06-01T16:20:07+09:00] ERROR: Running exception handlers
Running handlers complete

[2014-06-01T16:20:07+09:00] ERROR: Exception handlers complete
[2014-06-01T16:20:07+09:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
Chef Client failed. 52 resources updated in 425.683052906 seconds
[2014-06-01T16:20:07+09:00] ERROR: remote_file[/tmp/munin-common.deb] (munin-node::default line 43) had an error: Net::HTTPServerException: 404 "Not Found"
[2014-06-01T16:20:07+09:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
ERROR: RuntimeError: chef-solo failed. See output above.
```
