### PR TITLE
[tahr] sshdの再起動に失敗する

### DIFF
--- a/site-cookbooks/base/recipes/ssh.rb
+++ b/site-cookbooks/base/recipes/ssh.rb
@@ -22,5 +22,12 @@ template "/etc/ssh/sshd_config" do
 end
 
 service "ssh" do
-    action :nothing
+  case node["platform"]
+  when "ubuntu"
+    if node["platform_version"].to_f >= 13.10
+      provider Chef::Provider::Service::Upstart
+    end
+  end
+
+  action :nothing
 end


### PR DESCRIPTION
- [[#COOK-3910] ssh fails to start in Ubuntu 13.10 - Opscode Open Source Ticket Tracking](https://tickets.opscode.com/browse/COOK-3910)
- [[COOK-3910] Use Upstart provider for Ubuntu 13.10 by andreychernih · Pull Request #30 · opscode-cookbooks/openssh](https://github.com/opscode-cookbooks/openssh/pull/30)

どうやら

```
service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] && Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])

# [... snip ...]


service 'ssh' do
  provider service_provider
  # [... snip ...]
end
```

というようにする必要があるようだ。
