### PR TITLE
[tahr] rubygems packageの名前が変更になった

### DIFF
--- a/site-cookbooks/base/recipes/packages.rb
+++ b/site-cookbooks/base/recipes/packages.rb
@@ -41,9 +41,23 @@ package "screen" do
   action :install
 end
 
-%w{ ruby rubygems }.each do |p|
-  package p do
+# Ruby installation
+case node["platform"]
+when "ubuntu"
+  # common package: ruby
+  package "ruby" do
     action :install
+  end
+
+  # install ruby gem
+  if 12.10 <= node["platform_version"].to_f
+    package "rubygems-integration" do
+      action :install
+    end
+  elsif node["platform_version"].to_f < 12.10
+    package "rubygems" do
+      action :install
+    end
   end
 end
 


### PR DESCRIPTION
rubygemsのパッケージ名称が`Trusty Tahr`で変更になったため、Tahrの場合は`rubygems-integration`をインストールするようにする。
