### PR TITLE
php5-fpmソケットファイルのユーザ・グループ・パーミッションを明示的に指定する

### DIFF
--- a/site-cookbooks/wordpress/templates/default/www.conf.erb
+++ b/site-cookbooks/wordpress/templates/default/www.conf.erb
@@ -41,9 +41,9 @@ listen = /var/run/php5-fpm.sock
 ; BSD-derived systems allow connections regardless of permissions.
 ; Default Values: user and group are set as the running user
 ;                 mode is set to 0666
-;listen.owner = www-data
-;listen.group = www-data
-;listen.mode = 0666
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
 
 ; List of ipv4 addresses of FastCGI clients which are allowed to connect.
 ; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original


### PR DESCRIPTION
php5-fpmソケットファイルのユーザ・グループ・パーミッションを明示的に指定する:
- [Ubuntu precise で php5-fpm のソケットファイルのオーナー・グループが気づかぬうちに変わってた - kazu634's random thoughts](http://tech.kazu634.com/2014/06/25/php5-5-dot-3-10-1ubuntu3-dot-12-introduce-the-bug-about-the-php5-fpm-default-socket-user-and-group/)
