### PR TITLE
[Growthforecast] apt-get build-dep の部分で失敗しないようにする

### DIFF
--- a/site-cookbooks/growthforecast/recipes/prerequisites.rb
+++ b/site-cookbooks/growthforecast/recipes/prerequisites.rb
@@ -16,7 +16,7 @@ script "apt-get build-dep rrdtool" do
   group "root"
 
   code <<-EOH
-  apt-get -y build-dep rrdtool
+  apt-get -y build-dep rrdtool || true
   EOH
 end
 


### PR DESCRIPTION
`|| true`を追加します。
