### PR TITLE
MySQLのメモリ使用率のチューニングを行う

### DIFF
--- a/site-cookbooks/wordpress/templates/default/my.cnf.erb
+++ b/site-cookbooks/wordpress/templates/default/my.cnf.erb
@@ -55,7 +55,7 @@ thread_cache_size       = 8
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
 myisam-recover         = BACKUP
-#max_connections        = 100
+max_connections        = 10
 #table_cache            = 64
 #thread_concurrency     = 10
 #


### PR DESCRIPTION
[5分で出来るMySQLのお手軽チューニング - わーくあうと！](http://nick.hateblo.jp/entry/2014/01/26/183822) を参考にして MySQL のチューニングを実施する。

具体的には
- `MaxConnections`の設定値を調整する

see also:
- [誰も教えてくれなかったMySQLの障害解析方法 - Qiita](http://qiita.com/muran001/items/14f19959d4723ffc29cc) 
