### PR TITLE
[GrowthForecast] nginxの設定ファイルを見直し誤り

### DIFF
--- a/site-cookbooks/growthforecast/files/default/growth
+++ b/site-cookbooks/growthforecast/files/default/growth
@@ -5,7 +5,7 @@ upstream backend {
 
 server {
   listen 80;
-  server_name growth.kazu634.lan;
+  server_name growth.kazu634.com;
 
   access_log  /var/log/nginx/growthforecast.access.log ltsv;
   error_log   /var/log/nginx/growthforecast.error.log;


### PR DESCRIPTION
#92 の修正に誤りがあったため、修正する。修正内容は`Virtual Host`の設定。
