### PR TITLE
[Nginx] default設定を改め、virtual hostで設定していないリクエストを拒否する

### DIFF
--- a/site-cookbooks/nginx/templates/default/default.erb
+++ b/site-cookbooks/nginx/templates/default/default.erb
@@ -1,6 +1,6 @@
 server {
-  listen 80;
-  listen [::]:80 ipv6only=on;
+  # allow access from localhost
+  listen localhost:80;
 
   root /usr/share/nginx/html;
   index index.html index.htm;
@@ -11,3 +11,11 @@ server {
 
   }
 }
+
+# Denies the access without the pre-defined virtual host.
+server {
+  listen 80 default_server;
+    server_name _;
+
+  return 444;
+  }


### PR DESCRIPTION
`Growthforecast`で可視化すると、virtual host で設定していないリクエストが結構あることに気づいたので、以下の作業をするよ:
- `default`設定ファイルを削除する
- Virtual hostの設定をしていないリクエストを拒否するようにする
- `monit`で`Nginx`のポート80の監視をやめる
