### PR TITLE
[webapp] nginx配信時にgzip圧縮する

### DIFF
--- a/site-cookbooks/webapp/files/default/gcal
+++ b/site-cookbooks/webapp/files/default/gcal
@@ -3,8 +3,10 @@ upstream gcal {
 }
 
 server {
-  server_name calendar.kazu634.com;
   listen 80;
+  server_name calendar.kazu634.com;
+
+  gzip on;
 
   access_log  /var/log/nginx/calendar.access.log ltsv;
   error_log   /var/log/nginx/calendar.error.log;


### PR DESCRIPTION
```
         server {
        -  listen 80;
           server_name calendar.kazu634.com;
        -
        -  gzip on;
        +  listen 80;

           access_log  /var/log/nginx/calendar.access.log ltsv;
```
