### PR TITLE
[td-agent] 実行ユーザーをrootにする

### DIFF
--- a/site-cookbooks/fluentd-custom/recipes/td-agent.rb
+++ b/site-cookbooks/fluentd-custom/recipes/td-agent.rb
@@ -56,3 +56,11 @@ cookbook_file "/etc/monit/conf.d/td-agent.conf" do
 
   notifies :restart, "service[monit]"
 end
+
+# Enable `td-agent` to read the logs which cannot be opened by td-agent user.
+bash "Execute td-agent as a root" do
+  user "root"
+  code <<-EOH
+  sed -i 's/USER=td-agent/USER=root/' /etc/init.d/td-agent
+  EOH
+end


### PR DESCRIPTION
ログの所有者・パーミッションなどにより監視できないことがあるため、実行ユーザーを`root`にする。
