### PR TITLE
[td-agent] masterサーバに転送するための定義をデプロイする

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/forwarder.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder.conf
@@ -1,0 +1,19 @@
+<match fwd.**>
+  type forward
+  send_timeout 60s
+  recover_wait 10s
+  heartbeat_type tcp
+  heartbeat_interval 1s
+  phi_threshold 16
+  hard_timeout 60s
+
+  buffer_type file
+  buffer_path /var/log/td-agent/buffer/forward*.buffer
+
+  <server>
+    name growth.kazu634.com
+    host growth.kazu634.com
+    port 24224
+    weight 60
+  </server>
+</match>

--- a/site-cookbooks/fluentd-custom/recipes/td-agent.rb
+++ b/site-cookbooks/fluentd-custom/recipes/td-agent.rb
@@ -28,6 +28,18 @@ cookbook_file "/etc/td-agent/td-agent.conf" do
   notifies :restart, "service[td-agent]"
 end
 
+# deploy the `td-agent` configuration file for forwarding the logs
+cookbook_file "/etc/td-agent/conf.d/forwarder.conf" do
+  source "forwarder.conf"
+
+  owner "root"
+  group "root"
+
+  mode  0644
+
+  notifies :restart, "service[td-agent]"
+end
+
 # if the node accepts the forwarded logs
 if node[:td_agent][:forward]
   # deploy the configuration file for accepting the forwarded logs


### PR DESCRIPTION
```
<match fwd.**>
  type forward
  send_timeout 60s
  recover_wait 10s
  heartbeat_type tcp
  heartbeat_interval 1s
  phi_threshold 16
  hard_timeout 60s

  buffer_type file
  buffer_path /var/log/td-agent/buffer/forward*.buffer

  <server>
    name growth.kazu634.com
    host growth.kazu634.com
    port 24224
    weight 60
  </server>
</match>
```
