### PR TITLE
[td-agent] forwarder.conf をマネージャーサーバではデプロイしないようにする

### DIFF
--- a/site-cookbooks/fluentd-custom/recipes/td-agent.rb
+++ b/site-cookbooks/fluentd-custom/recipes/td-agent.rb
@@ -10,6 +10,10 @@
 include_recipe "chef-td-agent"
 include_recipe "iptables"
 
+###################
+# the common part #
+###################
+
 directory "/etc/td-agent/conf.d" do
   owner "root"
   group "root"
@@ -26,39 +30,6 @@ cookbook_file "/etc/td-agent/td-agent.conf" do
   mode  0644
 
   notifies :restart, "service[td-agent]"
-end
-
-# deploy the `td-agent` configuration file for forwarding the logs,
-# only if the server is one of the clients.
-cookbook_file "/etc/td-agent/conf.d/forwarder.conf" do
-  source "forwarder.conf"
-
-  owner "root"
-  group "root"
-
-  mode  0644
-
-  not_if { node[:td_agent][:forward] }
-
-  notifies :restart, "service[td-agent]"
-end
-
-# if the node is the manager:
-if node[:td_agent][:forward]
-  # deploy the configuration file for accepting the forwarded logs
-  cookbook_file "/etc/td-agent/conf.d/receiver.conf" do
-    source "receiver.conf"
-
-    owner "root"
-    group "root"
-
-    mode 0644
-
-    notifies :restart, "service[td-agent]"
-  end
-
-  # allow access from 24224 port
-  iptables_rule "receiver"
 end
 
 cookbook_file "/etc/monit/conf.d/td-agent.conf" do
@@ -78,4 +49,45 @@ bash "Execute td-agent as a root" do
   code <<-EOH
   sed -i 's/USER=td-agent/USER=root/' /etc/init.d/td-agent
   EOH
+end
+
+###################
+# The Client part #
+###################
+
+# deploy the `td-agent` configuration file for forwarding the logs,
+# only if the server is one of the clients.
+cookbook_file "/etc/td-agent/conf.d/forwarder.conf" do
+  source "forwarder.conf"
+
+  owner "root"
+  group "root"
+
+  mode  0644
+
+  not_if { node[:td_agent][:forward] }
+
+  notifies :restart, "service[td-agent]"
+end
+
+####################
+# The Manager part #
+####################
+
+# if the node is the manager:
+if node[:td_agent][:forward]
+  # deploy the configuration file for accepting the forwarded logs
+  cookbook_file "/etc/td-agent/conf.d/receiver.conf" do
+    source "receiver.conf"
+
+    owner "root"
+    group "root"
+
+    mode 0644
+
+    notifies :restart, "service[td-agent]"
+  end
+
+  # allow access from 24224 port
+  iptables_rule "receiver"
 end


### PR DESCRIPTION
`forwarder.conf`をマネージャーサーバではデプロイしないようにする
