### PR TITLE
Modify the typo in order to deploy the correct configuration file.

### DIFF
--- a/site-cookbooks/fluentd-custom/recipes/aptitude.rb
+++ b/site-cookbooks/fluentd-custom/recipes/aptitude.rb
@@ -31,8 +31,8 @@ cookbook_file "/etc/td-agent/conf.d/forwarder_aptitude.conf" do
 end
 
 # deploy the configuration file for processing /var/log/apt/history.log
-cookbook_file "/etc/td-agent/conf.d/processor_dstat.conf" do
-  source "processor_dstat.conf"
+cookbook_file "/etc/td-agent/conf.d/processor_aptitude.conf" do
+  source "processor_aptitude.conf"
 
   owner "root"
   group "root"


### PR DESCRIPTION
In order to deploy the configuration file for processing `aptitude` log
file, fix the following typo:

```
-cookbook_file "/etc/td-agent/conf.d/processor_dstat.conf" do
-  source "processor_dstat.conf"
+cookbook_file "/etc/td-agent/conf.d/processor_aptitude.conf" do
+  source "processor_aptitude.conf"

   owner "root"
  group "root"
```
