### PR TITLE
[WIP] Hotfix for `Support test-kitchen`.

### DIFF
--- a/roles/base.json
+++ b/roles/base.json
@@ -14,7 +14,6 @@
     "recipe[base]",
     "recipe[monit]",
     "recipe[kazu634]",
-    "recipe[nagios::nrpe]",
     "recipe[fluentd-custom]",
     "recipe[omnibus_updater]"
     ]}


### PR DESCRIPTION
This commit is intended not to
install the no-longer-exist recipe, `nagios::nrpe`.
