### PR TITLE
[WIP] Fix test for `Rabbitmq` installation.

### DIFF
--- a/site-cookbooks/sensu-custom/test/integration/server/serverspec/server_settings_spec.rb
+++ b/site-cookbooks/sensu-custom/test/integration/server/serverspec/server_settings_spec.rb
@@ -1,4 +1,5 @@
 require 'serverspec'
+require 'json'
 
 set :backend,  :exec
 


### PR DESCRIPTION
It seems that Ubuntu 12.04 explicitly state the following sentence:

```
require 'json'
```
