### PR TITLE
[WIP] Hotfix for the `serverspec`'s bahaviour change.

### DIFF
--- a/site-cookbooks/base/test/integration/default/serverspec/packages_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/packages_spec.rb
@@ -24,7 +24,7 @@ describe package('ruby') do
   it { should be_installed }
 end
 
-if os[:release].include?("precise")
+if os[:release] == "12.04"
   describe package('rubygems') do
     it { should be_installed }
   end


### PR DESCRIPTION
Serverspec offers the information about the target server, providing `os`
hashes.

Noticed that `os[:release]` does not return release names, such as
"precise", but rather "12.04".

Due to this behavioural change, tests breaks.
