### PR TITLE
[WIP] Skip building the docker image, when no cookbooks are modified.

### DIFF
--- a/tasks/tests/build-images.rake
+++ b/tasks/tests/build-images.rake
@@ -7,6 +7,14 @@ task :build do
   # Retrieve the list of the modified files:
   modified_files = `git diff --name-only master..\`git symbolic-ref HEAD\``
 
+  # If no cookbooks are modified, exit task:
+  unless modified_files.include?("site-cookbooks")
+    puts "No cookbooks are modified, so skip building the docker images."
+
+    exit
+  end
+
+  # building the docker images:
   %w{ ubuntu1204 ubuntu1404 }.each do |target_env|
     # change directory to docker/ubuntuxxxx:
     cd "docker/#{target_env}/" do


### PR DESCRIPTION
Skip building the docker images, when no cookbooks are modified.

This is because When no cookbooks are modified, the docker images are n ot used.
