### PR TITLE
[WIP] Test properly, when multiple cookbooks are modified.

### DIFF
--- a/tasks/tests/ci.rake
+++ b/tasks/tests/ci.rake
@@ -6,7 +6,7 @@ desc "Run CI tests."
 task :test do
   cookbooks = `git diff --name-only master..$(git symbolic-ref HEAD) | grep site-cookbooks | cut -f 2 -d / | awk '!a[$0]++'`
 
-  cookbooks.split('\n').each do |cookbook|
+  cookbooks.split("\n").each do |cookbook|
     cookbook.strip!
 
     cd "site-cookbooks/#{cookbook}/" do


### PR DESCRIPTION
When multiple cookbooks are modified, the current task does not test any
one of the cookbooks, because of the argument of the `split` function.

When specifying line-space, the argument should be surrounded by " not '.
