### PR TITLE
[WIP][sensu-custom] Modify the disk-usage collection interval from 3600 to 900 sec.

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/server_checks.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_checks.rb
@@ -67,7 +67,7 @@ sensu_check "disk-usage-metrics" do
   command "disk-usage-metrics.rb --scheme host:`uname -n`.disk_usage -f"
   handlers ["growthforecast"]
   subscribers ["all"]
-  interval 3600
+  interval 900
 end
 
 sensu_check "load-metrics" do


### PR DESCRIPTION
Noticed that the disk usage of `/var/www/proxy/blog_cache` exceeds 100%. We
want to detect this exceeding more earlier, so modify the disk-usage
collection interval.
