### PR TITLE
[WIP][base] Collect performance data, using `dstat`.

### DIFF
--- a/site-cookbooks/base/files/default/dstat
+++ b/site-cookbooks/base/files/default/dstat
@@ -1,3 +1,3 @@
 # Record `dstat` output to /tmp/dstat_YYYYMMDD.csv daily.
 
-0 0 * * * root /usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date "+%Y%m%d"`.csv 1 ${result} > /dev/null 2>&1
+0 0 * * * root /usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date "+%Y%m%d"`.csv 1 86400 > /dev/null 2>&1

--- a/site-cookbooks/base/files/default/dstat
+++ b/site-cookbooks/base/files/default/dstat
@@ -1,0 +1,3 @@
+# Record `dstat` output to /tmp/dstat_YYYYMMDD.csv daily.
+
+0 0 * * * root /usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date "+%Y%m%d"`.csv 1 ${result} > /dev/null 2>&1

--- a/site-cookbooks/base/files/default/dstat
+++ b/site-cookbooks/base/files/default/dstat
@@ -1,3 +1,3 @@
 # Record `dstat` output to /tmp/dstat_YYYYMMDD.csv daily.
 
-0 0 * * * root /usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date "+%Y%m%d"`.csv 1 86400 > /dev/null 2>&1
+0 0 * * * root /usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date +\%Y\%m\%d`.csv 1 86400 > /dev/null 2>&1

--- a/site-cookbooks/base/files/default/rc.local
+++ b/site-cookbooks/base/files/default/rc.local
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+# Calculate the UNIX epoch time of "Tommorrow midnight":
+# ex: if today is 2014/12/31, then calculate 2015/1/1 00:00:00.
+tmp=$(date -d '1 days' '+%Y/%m/%d 00:00:00')
+tomorrow=$(date -d "${tmp}" '+%s')
+
+# Calculate the UNIX epoch time of now:
+now=$(date '+%s')
+
+# Calculate the remaining time of today
+result=`expr ${tomorrow} - ${now}`
+
+/usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date "+%Y%m%d"`.csv 1 ${result} > /dev/null 2>&1 &
+
+exit 0

--- a/site-cookbooks/base/recipes/collect_performance.rb
+++ b/site-cookbooks/base/recipes/collect_performance.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: base
+# Recipe:: collect_performance
+#
+# Copyright 2013, YOUR_COMPANY_NAME
+#
+# All rights reserved - Do Not Redistribute
+#
+
+package "dstat" do
+  action :install
+end
+
+cookbook_file "/etc/cron.d/dstat" do
+  owner "root"
+  group "root"
+
+  mode 0644
+end
+
+cookbook_file "/etc/rc.local" do
+  owner "root"
+  group "root"
+
+  mode 0755
+end

--- a/site-cookbooks/base/recipes/default.rb
+++ b/site-cookbooks/base/recipes/default.rb
@@ -16,6 +16,7 @@ include_recipe "base::fortune"
 include_recipe "base::packages"
 include_recipe "base::timezone"
 include_recipe "base::ntp"
+include_recipe "base::collect_performance"
 
 # only install amd64 package
 # http://d.hatena.ne.jp/ritchey/20121229

--- a/site-cookbooks/base/recipes/packages.rb
+++ b/site-cookbooks/base/recipes/packages.rb
@@ -61,10 +61,6 @@ when "ubuntu"
   end
 end
 
-package "dstat" do
-  action :install
-end
-
 # curl installation:
 package "curl" do
   action :install

--- a/site-cookbooks/base/test/integration/default/serverspec/collect_performance_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/collect_performance_spec.rb
@@ -1,0 +1,27 @@
+require 'serverspec'
+
+describe package('dstat') do
+  it { should be_installed }
+end
+
+describe file('/etc/cron.d/dstat') do
+  it { should be_file }
+
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+
+  it { should be_mode 644 }
+
+  its(:md5sum) { should eq '9609f360fde168691a2a4ca50cb7b7c9' }
+end
+
+describe file('/etc/rc.local') do
+  it { should be_file }
+
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+
+  it { should be_mode 755 }
+
+  its(:md5sum) { should eq 'e1e975c666ce08e21c2e43f07b9889eb' }
+end

--- a/site-cookbooks/base/test/integration/default/serverspec/collect_performance_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/collect_performance_spec.rb
@@ -12,7 +12,7 @@ describe file('/etc/cron.d/dstat') do
 
   it { should be_mode 644 }
 
-  its(:md5sum) { should eq '9609f360fde168691a2a4ca50cb7b7c9' }
+  its(:md5sum) { should eq '7609f1b32368d01fa671c80085971bce' }
 end
 
 describe file('/etc/rc.local') do

--- a/site-cookbooks/base/test/integration/default/serverspec/packages_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/packages_spec.rb
@@ -34,10 +34,6 @@ else
   end
 end
 
-describe package('dstat') do
-  it { should be_installed }
-end
-
 describe package('curl') do
   it { should be_installed }
 end


### PR DESCRIPTION
Collect performance data, using `dstat`.
This is the command line to collect data:

  dstat -tlafip --output /tmp/dstat_`date +%Y%m%d`.csv 1 86400