### PR TITLE
[WIP] Configure `iptables` settings properly under `td-agent` server.

### DIFF
--- a/site-cookbooks/fluentd-custom/attributes/default.rb
+++ b/site-cookbooks/fluentd-custom/attributes/default.rb
@@ -3,6 +3,7 @@ default['td_agent']['api_key']      = 'foo'
 default['td_agent']['version']      = '2'
 default['td_agent']['forward']      = false
 default['td_agent']['base']         = true
+default['td_agent']['ssh']          = true
 
 # domain configuration
 default_unless['common']['domain']  = 'com'

--- a/site-cookbooks/fluentd-custom/templates/default/receiver.erb
+++ b/site-cookbooks/fluentd-custom/templates/default/receiver.erb
@@ -1,2 +1,3 @@
 # Port 24224 for fluentd
--A FWR -p tcp -m tcp,udp --dport 24224 -j ACCEPT
+-A FWR -p tcp --dport 24224 -j ACCEPT
+-A FWR -p udp --dport 24224 -j ACCEPT

--- a/tasks/tests/rubocop.rake
+++ b/tasks/tests/rubocop.rake
@@ -8,7 +8,7 @@ namespace :rubocop do
       # retrieve the list of the modified cookbooks:
       # rubocop:disable Metrics/LineLength
       modified_recipes =
-        `git diff --name-status master..$(git symbolic-ref HEAD) | grep site-cookbooks | grep -v ^D | awk '{ print $2 }'`
+        `git diff --name-status master..$(git symbolic-ref HEAD) | grep site-cookbooks | grep -v ^D | grep -v erb | awk '{ print $2 }'`
       # rubocop:enable Metrics/LineLength
 
       # if no cookbooks are modified, skip `rubocop`.


### PR DESCRIPTION
Because the `iptables` configuration is not proper,
the `iptables` does not function properly.

This commit is intended to fix this problem.