### PR TITLE
[WIP] Modify the `dstat` collection configuration:

### DIFF
--- a/site-cookbooks/base/files/default/dstat
+++ b/site-cookbooks/base/files/default/dstat
@@ -1,3 +1,3 @@
 # Record `dstat` output to /tmp/dstat_YYYYMMDD.csv daily.
 
-0 0 * * * root /usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date +\%Y\%m\%d`.csv 1 86400 > /dev/null 2>&1
+0 0 * * * root /usr/bin/dstat -tlafip --nocolor --output /tmp/dstat_`date +\%Y\%m\%d`.csv 1 86400 > /dev/null 2>&1

--- a/site-cookbooks/base/files/default/rc.local
+++ b/site-cookbooks/base/files/default/rc.local
@@ -22,6 +22,6 @@ now=$(date '+%s')
 # Calculate the remaining time of today
 result=`expr ${tomorrow} - ${now}`
 
-/usr/bin/dstat -t --top-cpu-adv --top-io --top-bio -lafip --nocolor --output /tmp/dstat_`date "+%Y%m%d"`.csv 1 ${result} > /dev/null 2>&1 &
+/usr/bin/dstat -tlafip --nocolor --output /tmp/dstat_`date "+%Y%m%d"`.csv 1 ${result} > /dev/null 2>&1 &
 
 exit 0

--- a/site-cookbooks/base/test/integration/default/serverspec/collect_performance_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/collect_performance_spec.rb
@@ -12,7 +12,7 @@ describe file('/etc/cron.d/dstat') do
 
   it { should be_mode 644 }
 
-  its(:md5sum) { should eq '7609f1b32368d01fa671c80085971bce' }
+  its(:md5sum) { should eq 'ed90023b94388b59dd7db753c2759344' }
 end
 
 describe file('/etc/rc.local') do
@@ -23,5 +23,5 @@ describe file('/etc/rc.local') do
 
   it { should be_mode 755 }
 
-  its(:md5sum) { should eq 'e1e975c666ce08e21c2e43f07b9889eb' }
+  its(:md5sum) { should eq 'c902d7adc4060daab00a1986a9f9f875' }
 end

--- a/tasks/tests/rubocop.rake
+++ b/tasks/tests/rubocop.rake
@@ -8,7 +8,7 @@ namespace :rubocop do
       # retrieve the list of the modified cookbooks:
       # rubocop:disable Metrics/LineLength
       modified_recipes =
-        `git diff --name-status master..$(git symbolic-ref HEAD) | grep site-cookbooks | grep -v ^D | grep -v erb | awk '{ print $2 }'`
+        `git diff --name-status master..$(git symbolic-ref HEAD) | grep ".rb" | awk '{ print $2 }'`
       # rubocop:enable Metrics/LineLength
 
       # if no cookbooks are modified, skip `rubocop`.


### PR DESCRIPTION
Noticed that the collection of

- CPU-busy process info
- IO-busy process info

are too informative. So, remove these info.