### PR TITLE
[WIP] Unmonitor `/var/log/monit.log`.

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/deploy_scripts.rb
+++ b/site-cookbooks/sensu-custom/recipes/deploy_scripts.rb
@@ -15,14 +15,6 @@ remote_file '/etc/sensu/plugins/check-procs.rb' do
   mode 0755
 end
 
-remote_file '/etc/sensu/plugins/check-log.rb' do
-  source 'https://raw.github.com/sensu/sensu-community-plugins/master/plugins/logging/check-log.rb'
-
-  user 'sensu'
-  group 'sensu'
-  mode 0755
-end
-
 remote_file '/etc/sensu/plugins/check-load.rb' do
   source 'https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-load.rb'
 

--- a/site-cookbooks/sensu-custom/recipes/server_checks.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_checks.rb
@@ -7,13 +7,6 @@
 # All rights reserved - Do Not Redistribute
 #
 
-sensu_check 'monit_log' do
-  command '/usr/bin/sudo /etc/sensu/plugins/check-log.rb -f /var/log/monit.log -q error -s /var/tmp/'
-  handlers ['default']
-  subscribers ['all']
-  interval 120
-end
-
 sensu_check 'load_average' do
   command '/etc/sensu/plugins/check-load.rb -w 1,1,1 -c 2,2,2 -p'
   handlers ['default']

--- a/site-cookbooks/sensu-custom/test/integration/default/serverspec/deploy_scripts_spec.rb
+++ b/site-cookbooks/sensu-custom/test/integration/default/serverspec/deploy_scripts_spec.rb
@@ -3,7 +3,6 @@ require 'serverspec'
 set :backend,  :exec
 
 scripts = %w(/etc/sensu/plugins/check-procs.rb
-             /etc/sensu/plugins/check-log.rb
              /etc/sensu/plugins/check-load.rb
              /etc/sensu/plugins/check-swap.sh
              /etc/sensu/plugins/check-disk.rb

--- a/site-cookbooks/sensu-custom/test/integration/server/serverspec/deploy_scripts_spec.rb
+++ b/site-cookbooks/sensu-custom/test/integration/server/serverspec/deploy_scripts_spec.rb
@@ -3,7 +3,6 @@ require 'serverspec'
 set :backend,  :exec
 
 scripts = %w(/etc/sensu/plugins/check-procs.rb
-             /etc/sensu/plugins/check-log.rb
              /etc/sensu/plugins/check-load.rb
              /etc/sensu/plugins/check-swap.sh
              /etc/sensu/plugins/check-disk.rb


### PR DESCRIPTION
Because, `td-agent` also notifies the error log to `Slack`,
`Sensu` need not monitor `/var/log/monit.log`.