### PR TITLE
[WIP] Notify when reboot is required.

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/deploy_scripts.rb
+++ b/site-cookbooks/sensu-custom/recipes/deploy_scripts.rb
@@ -38,6 +38,13 @@ remote_file '/etc/sensu/plugins/check-disk.rb' do
   mode 0755
 end
 
+remote_file '/etc/sensu/plugins/check-file-exists.rb' do
+  source 'https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/files/check-file-exists.rb'
+  user 'sensu'
+  group 'sensu'
+  mode 0755
+end
+
 # Slack notification:
 remote_file '/etc/sensu/handlers/slack.rb' do
   source 'https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/handlers/notification/slack.rb'

--- a/site-cookbooks/sensu-custom/recipes/server_checks.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_checks.rb
@@ -56,6 +56,13 @@ end
   end
 end
 
+sensu_check 'reboot-required' do
+  command '/etc/sensu/plugins/check-file-exists.rb -c /var/run/reboot-required'
+  handlers ['default']
+  subscribers ['all']
+  interval 3600
+end
+
 # Sensu-Growthforecast integration:
 sensu_check 'cpu-pcnt-usage-metrics' do
   type 'metric'

--- a/site-cookbooks/sensu-custom/test/integration/default/serverspec/deploy_scripts_spec.rb
+++ b/site-cookbooks/sensu-custom/test/integration/default/serverspec/deploy_scripts_spec.rb
@@ -7,6 +7,7 @@ scripts = %w(/etc/sensu/plugins/check-procs.rb
              /etc/sensu/plugins/check-swap.sh
              /etc/sensu/plugins/check-disk.rb
              /etc/sensu/plugins/cpu-pcnt-usage-metrics.rb
+             /etc/sensu/plugins/check-file-exists.rb
              /etc/sensu/plugins/disk-usage-metrics.rb
              /etc/sensu/plugins/load-metrics.rb
              /etc/sensu/plugins/memory-metrics.rb

--- a/site-cookbooks/sensu-custom/test/integration/server/serverspec/deploy_scripts_spec.rb
+++ b/site-cookbooks/sensu-custom/test/integration/server/serverspec/deploy_scripts_spec.rb
@@ -7,6 +7,7 @@ scripts = %w(/etc/sensu/plugins/check-procs.rb
              /etc/sensu/plugins/check-swap.sh
              /etc/sensu/plugins/check-disk.rb
              /etc/sensu/plugins/cpu-pcnt-usage-metrics.rb
+             /etc/sensu/plugins/check-file-exists.rb
              /etc/sensu/plugins/disk-usage-metrics.rb
              /etc/sensu/plugins/load-metrics.rb
              /etc/sensu/plugins/memory-metrics.rb


### PR DESCRIPTION
If `/var/run/reboot-required` exists, it means the reboot is required. We
should detect the file's existence and determine if we could reboot or not.