### PR TITLE
[WIP] Modify `Sensu` check configuration to propery handle `disk-usage-metrics.rb`:

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/server_checks.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_checks.rb
@@ -74,7 +74,7 @@ end
 
 sensu_check 'disk-usage-metrics' do
   type 'metric'
-  command 'disk-usage-metrics.rb --scheme host:`uname -n`.disk_usage -f'
+  command 'disk-usage-metrics.rb --scheme host:`uname -n` -f'
   handlers ['growthforecast']
   subscribers ['all']
   interval 900


### PR DESCRIPTION
`disk-usage-metrics.rb` changes the output format of the result,
so the metrics collection has been broken.

This commit fixes this problem.