### PR TITLE
[WIP] Specify `UseDNS` to be no.

### DIFF
--- a/site-cookbooks/base/templates/default/sshd_config.erb
+++ b/site-cookbooks/base/templates/default/sshd_config.erb
@@ -85,3 +85,6 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
+
+# Do not use DNS:
+UseDNS no

--- a/site-cookbooks/base/templates/ubuntu-14.04/sshd_config.erb
+++ b/site-cookbooks/base/templates/ubuntu-14.04/sshd_config.erb
@@ -86,3 +86,6 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
+
+# Do not use DNS:
+UseDNS no


### PR DESCRIPTION
Specify `UseDNS` to be no in order to shorten the SSH connection time.

see: [SSHサーバへ接続出来ない・遅い時の原因と対処法](http://orebibou.com/2014/12/ssh%E3%82%B5%E3%83%BC%E3%83%90%E3%81%B8%E6%8E%A5%E7%B6%9A%E5%87%BA%E6%9D%A5%E3%81%AA%E3%81%84%E3%83%BB%E9%81%85%E3%81%84%E6%99%82%E3%81%AE%E5%8E%9F%E5%9B%A0%E3%81%A8%E5%AF%BE%E5%87%A6%E6%B3%95/)