### PR TITLE
[WIP] Do not detect the unnecessary logs of `/var/log/td-agent/td-agent.log`.

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/log_monitor.rb
+++ b/site-cookbooks/sensu-custom/recipes/log_monitor.rb
@@ -18,7 +18,7 @@ end
 
 # check `/var/log/td-agent/td-agent.log` to check whether `td-agent` is working properly.
 sensu_check 'td-agent-log' do
-  command "/usr/bin/sudo /etc/sensu/plugins/check-log.rb -f /var/log/td-agent/td-agent.log --pattern '.*' --exclude info -s /var/tmp/"
+  command "/usr/bin/sudo /etc/sensu/plugins/check-log.rb -f /var/log/td-agent/td-agent.log --pattern '.*' --exclude '(info|^ |</ROOT>)' -s /var/tmp/"
   handlers ['default']
   subscribers ['all']
   interval 600


### PR DESCRIPTION
As for now `Sensu` detect the unnecessary logs as critical,
we will modify the monitoring condition to monitor properly.