### PR TITLE
[WIP] Restart `nginx` if `nginx` stops logging.

### DIFF
--- a/site-cookbooks/wordpress/files/default/wordpress-log.conf
+++ b/site-cookbooks/wordpress/files/default/wordpress-log.conf
@@ -1,0 +1,2 @@
+check file nginx-blog with path /var/log/nginx/front_proxy.access.log
+    if timestamp > 2 minutes for 5 cycles then exec "/etc/init.d/nginx restart"

--- a/site-cookbooks/wordpress/recipes/nginx.rb
+++ b/site-cookbooks/wordpress/recipes/nginx.rb
@@ -30,3 +30,13 @@ end
 link '/etc/nginx/sites-enabled/wordpress' do
   to '/etc/nginx/sites-available/wordpress'
 end
+
+cookbook_file '/etc/monit/conf.d/wordpress-log.conf' do
+  source 'wordpress-log.conf'
+
+  owner 'root'
+  group 'root'
+  mode 0644
+
+  notifies :reload, 'service[monit]'
+end


### PR DESCRIPTION
Sometimes, `nginx` stops logging, after log rotation.

This commit monitors the `nginx` log file size,
and if it detects the logging stop, restart `nginx`.