### PR TITLE
[WIP] Log the Dropped Packets to `/var/log/syslog`

### DIFF
--- a/site-cookbooks/base/recipes/default.rb
+++ b/site-cookbooks/base/recipes/default.rb
@@ -97,3 +97,7 @@ gem_package 'ruby-shadow' do
   gem_binary '/opt/chef/embedded/bin/gem'
   action :install
 end
+
+# Log the Dropped Packets to `/var/log/syslog`:
+include_recipe 'iptables'
+iptables_rule 'packet_drop_log'

--- a/site-cookbooks/base/templates/default/packet_drop_log.erb
+++ b/site-cookbooks/base/templates/default/packet_drop_log.erb
@@ -1,0 +1,2 @@
+# SSH daemon iptables rule
+-A FWR -j LOG -m limit --log-prefix "[Packet Dropped] "

--- a/site-cookbooks/base/test/integration/default/serverspec/default_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/default_spec.rb
@@ -32,3 +32,8 @@ if os[:release].to_f >= 14.04 && os[:family] == 'ubuntu'
     its(:md5sum) { should eq '864ab49c4f5e857ef7f87bec0b129e1d' }
   end
 end
+
+# `iptables` rule to log the dropped packets:
+# describe iptables do
+#   it { should have_rule '-A FWR -m limit --limit 3/hour -j LOG --log-prefix' }
+# end


### PR DESCRIPTION
Change the `iptables` configuration to log the dropped packets
to `/var/log/syslog`.