### PR TITLE
[WIP] Use `build-essentials`, instead of `base`:

### DIFF
--- a/site-cookbooks/fluentd-custom/.kitchen.yml
+++ b/site-cookbooks/fluentd-custom/.kitchen.yml
@@ -25,7 +25,6 @@ suites:
   - name: server
     run_list:
       - recipe[fluentd-custom::default]
-      - recipe[base::packages]
     attributes:
       td_agent:
         forward: true

--- a/site-cookbooks/fluentd-custom/Berksfile
+++ b/site-cookbooks/fluentd-custom/Berksfile
@@ -3,4 +3,3 @@ site :opscode
 metadata
 cookbook 'td-agent', git: 'https://github.com/treasure-data/chef-td-agent.git'
 cookbook 'monit', path: '../monit'
-cookbook 'base', path: '../base'

--- a/site-cookbooks/fluentd-custom/metadata.rb
+++ b/site-cookbooks/fluentd-custom/metadata.rb
@@ -7,6 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'td-agent'
+depends 'apt'
 depends 'build-essential'
 depends 'monit'
 depends 'iptables'

--- a/site-cookbooks/fluentd-custom/metadata.rb
+++ b/site-cookbooks/fluentd-custom/metadata.rb
@@ -7,5 +7,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'td-agent'
+depends 'build-essential'
 depends 'monit'
 depends 'iptables'

--- a/site-cookbooks/fluentd-custom/recipes/prerequisites.rb
+++ b/site-cookbooks/fluentd-custom/recipes/prerequisites.rb
@@ -7,6 +7,7 @@
 # All rights reserved - Do Not Redistribute
 #
 
+include_recipe 'apt'
 include_recipe 'build-essential'
 include_recipe 'monit'
 

--- a/site-cookbooks/fluentd-custom/recipes/prerequisites.rb
+++ b/site-cookbooks/fluentd-custom/recipes/prerequisites.rb
@@ -7,6 +7,7 @@
 # All rights reserved - Do Not Redistribute
 #
 
+include_recipe 'build-essential'
 include_recipe 'monit'
 
 cookbook_file '/etc/security/limits.d/90-nfile.conf' do


### PR DESCRIPTION
Since `base` cookbook is too much when testing `fluentd-custom` cookbook.
Our minimal requirement is `build-essentials`.

So use `build-essentials`, instead of `base`.