### PR TITLE
[WIP] Omit the unnecessary dependencies from the `ruby` cookbook.

### DIFF
--- a/site-cookbooks/ruby/Berksfile
+++ b/site-cookbooks/ruby/Berksfile
@@ -1,4 +1,3 @@
 site :opscode
 
 metadata
-cookbook 'base', path: '../base'

--- a/site-cookbooks/ruby/metadata.rb
+++ b/site-cookbooks/ruby/metadata.rb
@@ -8,5 +8,3 @@ version '0.1.0'
 
 depends 'apt'
 depends 'build-essential'
-depends 'base'
-depends 'iptables'

--- a/site-cookbooks/ruby/recipes/default.rb
+++ b/site-cookbooks/ruby/recipes/default.rb
@@ -9,7 +9,6 @@
 
 include_recipe 'apt'
 include_recipe 'build-essential'
-include_recipe 'base'
 
 pre_requisites = %w(libreadline-dev libssl-dev zlib1g-dev libssl1.0.0 libxml2-dev libxslt-dev libreadline6 libreadline6-dev)
 


### PR DESCRIPTION
There are unnecessary dependencies in the `ruby` cookbook.

In order to speed-up the testing,
exclude the unnecessary dependencies from `ruby` cookbook.