### PR TITLE
[WIP] Add `iptables` rules for sensu, redis, rabbitmq.

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/server_settings.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_settings.rb
@@ -17,7 +17,9 @@ include_recipe 'sensu-custom::server_handlers'
 if node['sensu-custom']['iptables']
   include_recipe 'iptables'
 
+  iptables_rule 'redis'
   iptables_rule 'rabbitmq'
+  iptables_rule 'sensu-iptables'
 end
 
 %w(redis.conf rabbitmq.conf sensu-server.conf sensu-api.conf uchiwa.conf).each do |conf|

--- a/site-cookbooks/sensu-custom/templates/default/rabbitmq.erb
+++ b/site-cookbooks/sensu-custom/templates/default/rabbitmq.erb
@@ -1,2 +1,2 @@
-# Port 80 for rabbitmq
+# Port 5671 for rabbitmq
 -A FWR -p tcp -m tcp --dport 5671 -j ACCEPT

--- a/site-cookbooks/sensu-custom/templates/default/redis.erb
+++ b/site-cookbooks/sensu-custom/templates/default/redis.erb
@@ -1,0 +1,2 @@
+# Port 6379 for redis
+-A FWR -p tcp -m tcp --dport 6379 -j ACCEPT

--- a/site-cookbooks/sensu-custom/templates/default/sensu-iptables.erb
+++ b/site-cookbooks/sensu-custom/templates/default/sensu-iptables.erb
@@ -1,0 +1,2 @@
+# Port 4567 for sensu-api
+-A FWR -p tcp -m tcp --dport 4567 -j ACCEPT


### PR DESCRIPTION
While testing, we noticed that we cannot connect to sensu and redis.
In order to access to sense and redis, we add `iptables` rules.