### PR TITLE
[WIP] Install default `iptables` rules.

### DIFF
--- a/site-cookbooks/base/recipes/default.rb
+++ b/site-cookbooks/base/recipes/default.rb
@@ -18,6 +18,7 @@ include_recipe 'base::timezone'
 include_recipe 'base::ntp'
 include_recipe 'base::collect_performance'
 include_recipe 'base::kernel'
+include_recipe 'base::iptables'
 
 # only install amd64 package
 # http://d.hatena.ne.jp/ritchey/20121229
@@ -97,7 +98,3 @@ gem_package 'ruby-shadow' do
   gem_binary '/opt/chef/embedded/bin/gem'
   action :install
 end
-
-# Log the Dropped Packets to `/var/log/syslog`:
-include_recipe 'iptables'
-iptables_rule 'packet_drop_log'

--- a/site-cookbooks/base/recipes/iptables.rb
+++ b/site-cookbooks/base/recipes/iptables.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: base
+# Recipe:: iptables
+#
+# Copyright 2013, YOUR_COMPANY_NAME
+#
+# All rights reserved - Do Not Redistribute
+#
+
+include_recipe 'iptables'
+
+# `iptables` basic configurations:
+iptables_rule 'all_established'
+iptables_rule 'all_icmp'
+iptables_rule 'postfix'
+iptables_rule 'prefix'
+
+# Log the Dropped Packets to `/var/log/syslog`:
+iptables_rule 'packet_drop_log'

--- a/site-cookbooks/base/templates/default/all_established.erb
+++ b/site-cookbooks/base/templates/default/all_established.erb
@@ -1,0 +1,2 @@
+# Any established connection is money
+-A FWR -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/site-cookbooks/base/templates/default/all_icmp.erb
+++ b/site-cookbooks/base/templates/default/all_icmp.erb
@@ -1,0 +1,2 @@
+# ICMP
+-A FWR -p icmp -j ACCEPT

--- a/site-cookbooks/base/templates/default/postfix.erb
+++ b/site-cookbooks/base/templates/default/postfix.erb
@@ -1,0 +1,2 @@
+-A FWR -p tcp -m tcp --tcp-flags SYN,RST,ACK SYN -j DROP
+-A FWR -p udp -j DROP

--- a/site-cookbooks/base/templates/default/prefix.erb
+++ b/site-cookbooks/base/templates/default/prefix.erb
@@ -1,0 +1,2 @@
+-A INPUT -j FWR
+-A FWR -i lo -j ACCEPT


### PR DESCRIPTION
Since `iptables` cookbook no longer deploy the following rules,
the `base` cookbook will deploy the following rules:

- `all_established`
- `all_icmp`
- `prefix`
- `postfix`