### PR TITLE
[WIP] Create a dedicated recipe to install `git`.

### DIFF
--- a/site-cookbooks/base/recipes/git_config.rb
+++ b/site-cookbooks/base/recipes/git_config.rb
@@ -7,6 +7,20 @@
 # All rights reserved - Do Not Redistribute
 #
 
+apt_repository 'git' do
+  uri 'http://ppa.launchpad.net/git-core/ppa/ubuntu'
+  distribution node['lsb']['codename']
+  components ['main']
+  keyserver 'keyserver.ubuntu.com'
+  key 'E1DF1F24'
+end
+
+package 'git-core' do
+  action :install
+
+  options '--force-yes'
+end
+
 remote_file '/usr/share/git-core/templates/hooks/pre-push' do
   source 'https://gist.github.com/kazu634/8267388/raw/e9202cd4c29a66723c88d2be05f3cd19413d2137/pre-push'
 

--- a/site-cookbooks/base/recipes/packages.rb
+++ b/site-cookbooks/base/recipes/packages.rb
@@ -13,20 +13,7 @@ package 'zsh' do
   not_if 'which zsh'
 end
 
-apt_repository 'git' do
-  uri 'http://ppa.launchpad.net/git-core/ppa/ubuntu'
-  distribution node['lsb']['codename']
-  components ['main']
-  keyserver 'keyserver.ubuntu.com'
-  key 'E1DF1F24'
-end
-
-package 'git-core' do
-  action :install
-
-  options '--force-yes'
-end
-
+# install `git`:
 include_recipe 'base::git_config'
 
 package 'vim-nox' do

--- a/site-cookbooks/base/test/integration/default/serverspec/git_config_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/git_config_spec.rb
@@ -1,5 +1,9 @@
 require 'serverspec'
 
+describe package('git-core') do
+  it { should be_installed }
+end
+
 describe file('/usr/share/git-core/templates/hooks/pre-commit') do
   it { should be_readable }
   it { should be_executable }

--- a/site-cookbooks/base/test/integration/default/serverspec/packages_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/packages_spec.rb
@@ -4,10 +4,6 @@ describe package('zsh') do
   it { should be_installed }
 end
 
-describe package('git-core') do
-  it { should be_installed }
-end
-
 describe package('vim-nox') do
   it { should be_installed }
 end


### PR DESCRIPTION
In order for `webapp` cookbook to install `git`,
create a dedicated recipe to install `git`.