### PR TITLE
[WIP] Install `nginx` automatically, if the specified version is not installed.

### DIFF
--- a/site-cookbooks/nginx/recipes/build.rb
+++ b/site-cookbooks/nginx/recipes/build.rb
@@ -76,7 +76,7 @@ bash 'Install nginx' do
   EOH
   user 'root'
 
-  not_if { File.exist?('/usr/share/nginx/sbin/nginx') }
+  not_if "/usr/share/nginx/sbin/nginx -v 2>&1 | grep #{version}"
 end
 
 cookbook_file '/etc/init.d/nginx' do


### PR DESCRIPTION
If the specified version of `nginx` is not installed,
install `nginx` automatically.