### PR TITLE
[WIP] Enable `monit` monitoring for `nginx`

### DIFF
--- a/site-cookbooks/nginx/recipes/setup.rb
+++ b/site-cookbooks/nginx/recipes/setup.rb
@@ -50,9 +50,20 @@ link '/etc/nginx/sites-enabled/maintenance' do
   owner 'root'
   group 'root'
   mode 0644
+
   notifies :restart, 'service[nginx]'
 
   not_if { File.exist?('/etc/nginx/sites-enabled/maintenance') || File.exist?('/etc/nginx/sites-enabled/default') }
+end
+
+cookbook_file '/etc/monit/conf.d/nginx.conf' do
+  source 'nginx.conf'
+
+  user 'root'
+  group 'root'
+  mode 0644
+
+  notifies :restart, 'service[monit]'
 end
 
 service 'nginx' do

--- a/site-cookbooks/nginx/test/integration/default/serverspec/setup_spec.rb
+++ b/site-cookbooks/nginx/test/integration/default/serverspec/setup_spec.rb
@@ -24,6 +24,14 @@ describe file('/etc/nginx/nginx.conf') do
   it { should be_mode 644 }
 end
 
+describe file('/etc/monit/conf.d/nginx.conf') do
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+
+  its(:md5sum) { should eq '4d7f0276e7efea61d687a2886cfa5569' }
+end
+
 describe file('/etc/nginx/sites-available/default') do
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }


### PR DESCRIPTION
As b2e2a unintentionally deletes the `monit` configuration file for `nginx`,
this will re-deploy the `monit` configuration file for `nginx`.