### PR TITLE
[WIP] Use `Ruby`'s old-style hash writing.

### DIFF
--- a/site-cookbooks/serf/recipes/setup.rb
+++ b/site-cookbooks/serf/recipes/setup.rb
@@ -60,10 +60,9 @@ if node['serf']['manager']
     group node['serf']['group']
     mode 00644
 
-    variables AWS: {
+    variables(
       AWS: AWS,
-      PUBLIC_IP: PUBLIC_IP
-    }
+      PUBLIC_IP: PUBLIC_IP)
 
     notifies :restart, 'service[serf]'
   end
@@ -88,10 +87,9 @@ else
     group node['serf']['group']
     mode 00644
 
-    variables AWS: {
+    variables(
       AWS: AWS,
-      PUBLIC_IP: PUBLIC_IP
-    }
+      PUBLIC_IP: PUBLIC_IP)
 
     notifies :restart, 'service[serf]'
   end

--- a/site-cookbooks/serf/templates/default/serf.json.erb
+++ b/site-cookbooks/serf/templates/default/serf.json.erb
@@ -14,8 +14,8 @@
   "interface": "eth0",
   "encrypt_key": "jEHtR8ufU7H9wVPkR3yucw==",
   "profile": "wan",
-  <% if @AWS['AWS']  == true %>
-  "advertise": "<%= @AWS['PUBLIC_IP'] %>",
+  <% if @AWS  == true %>
+  "advertise": "<%= @PUBLIC_IP %>",
   <% end %>
 
   "reconnect_timeout": "30m",


### PR DESCRIPTION
It seems that template resource does not support `Ruby`'s new style hash.
Because of this, `serf`'s AWS support is broken.