### PR TITLE
[WIP] Version up `Nginx` for `Growthforecast`

### DIFF
--- a/site-cookbooks/growthforecast/recipes/growthforecast.rb
+++ b/site-cookbooks/growthforecast/recipes/growthforecast.rb
@@ -41,7 +41,7 @@ directory '/var/log/growthforecast' do
 end
 
 service 'growthforecast' do
-  supports restart: true,   start: true,   stop: true
+  supports restart: true, start: true, stop: true
   action :nothing
 end
 
@@ -83,7 +83,7 @@ bash 'Delete the nginx maintenance file' do
   rm /etc/nginx/sites-enabled/maintenance
   EOH
 
-  only_if { File.exists?('/etc/nginx/sites-enabled/maintenance') }
+  only_if { File.exist?('/etc/nginx/sites-enabled/maintenance') }
 end
 
 %w( growthforecast default ).each do |conf|

--- a/site-cookbooks/growthforecast/recipes/growthforecast.rb
+++ b/site-cookbooks/growthforecast/recipes/growthforecast.rb
@@ -55,7 +55,7 @@ cookbook_file '/etc/init.d/growthforecast' do
   notifies :start,   'service[growthforecast]'
 end
 
-template '/etc/nginx/sites-available/growth' do
+template '/etc/nginx/sites-available/growthforecast' do
   source 'growth.erb'
 
   owner 'root'
@@ -75,6 +75,19 @@ cookbook_file '/etc/nginx/.htpasswd_growth' do
   notifies :restart, 'service[nginx]'
 end
 
-link '/etc/nginx/sites-enabled/growthforecast' do
-  to '/etc/nginx/sites-available/growth'
+bash 'Delete the nginx maintenance file' do
+  user 'root'
+  group 'root'
+
+  code <<-EOH
+  rm /etc/nginx/sites-enabled/maintenance
+  EOH
+
+  only_if { File.exists?('/etc/nginx/sites-enabled/maintenance') }
+end
+
+%w( growthforecast default ).each do |conf|
+  link "/etc/nginx/sites-enabled/#{conf}" do
+    to "/etc/nginx/sites-available/#{conf}"
+  end
 end

--- a/site-cookbooks/growthforecast/test/integration/default/serverspec/growthforecast_spec.rb
+++ b/site-cookbooks/growthforecast/test/integration/default/serverspec/growthforecast_spec.rb
@@ -1,6 +1,6 @@
 require 'serverspec'
 
-set :backend,  :exec
+set :backend, :exec
 
 describe file('/var/lib/growthforecast/appdata') do
   it { should be_directory }
@@ -36,7 +36,7 @@ describe service('growthforecast') do
   it { should be_running }
 end
 
-describe file('/etc/nginx/sites-available/growth') do
+describe file('/etc/nginx/sites-available/growthforecast') do
   it { should be_file }
 
   it { should be_owned_by 'root' }
@@ -57,5 +57,5 @@ describe file('/etc/nginx/.htpasswd_growth') do
 end
 
 describe file('/etc/nginx/sites-enabled/growthforecast') do
-  it { should be_linked_to '/etc/nginx/sites-available/growth' }
+  it { should be_linked_to '/etc/nginx/sites-available/growthforecast' }
 end


### PR DESCRIPTION
Because we'd like to version up `Nginx` to support `http/2`,
we need to make sure that our `Growthforecast` cookbook will work
even after versioning up `Nginx`.