### PR TITLE
[WIP] Version up `Nginx` for `Sensu`

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/server_settings.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_settings.rb
@@ -50,7 +50,7 @@ bash 'Delete the nginx maintenance file' do
   rm /etc/nginx/sites-enabled/maintenance
   EOH
 
-  only_if { File.exists?('/etc/nginx/sites-enabled/maintenance') }
+  only_if { File.exist?('/etc/nginx/sites-enabled/maintenance') }
 end
 
 %w( sensu default ).each do |conf|

--- a/site-cookbooks/sensu-custom/recipes/server_settings.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_settings.rb
@@ -42,10 +42,23 @@ template '/etc/nginx/sites-available/sensu' do
   notifies :restart, 'service[nginx]'
 end
 
-link '/etc/nginx/sites-enabled/sensu' do
-  to '/etc/nginx/sites-available/sensu'
+bash 'Delete the nginx maintenance file' do
+  user 'root'
+  group 'root'
 
-  not_if 'test -e /etc/nginx/sites-enabled/sensu'
+  code <<-EOH
+  rm /etc/nginx/sites-enabled/maintenance
+  EOH
+
+  only_if { File.exists?('/etc/nginx/sites-enabled/maintenance') }
+end
+
+%w( sensu default ).each do |conf|
+  link "/etc/nginx/sites-enabled/#{conf}" do
+    to "/etc/nginx/sites-available/#{conf}"
+
+    not_if "test -e /etc/nginx/sites-enabled/#{conf}"
+  end
 end
 
 service 'nginx' do


### PR DESCRIPTION
Because we'd like to version up `Nginx` to support `http/2`,
we need to make sure that our `Sensu` cookbook will work
even after versioning up `Nginx`.