### PR TITLE
[WIP] Change the `serf` download URL

### DIFF
--- a/site-cookbooks/serf/attributes/default.rb
+++ b/site-cookbooks/serf/attributes/default.rb
@@ -1,11 +1,11 @@
 default['serf']['user'] = '_serf'
 default['serf']['group'] = '_serf'
 
-default['serf']['base_binary_url'] = 'https://dl.bintray.com/mitchellh/serf/'
-default['serf']['version'] = '0.6.3'
+default['serf']['version'] = '0.7.0'
+default['serf']['base_binary_url'] = "https://releases.hashicorp.com/serf/#{node['serf']['version']}/"
 default['serf']['arch'] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
 
-default['serf']['binary_url'] = File.join node['serf']['base_binary_url'], "#{node['serf']['version']}_linux_#{node['serf']['arch']}.zip"
+default['serf']['binary_url'] = File.join node['serf']['base_binary_url'], "serf_#{node['serf']['version']}_linux_#{node['serf']['arch']}.zip"
 
 default['serf']['tmp_path'] = File.join Chef::Config[:file_cache_path], "serf-#{node['serf']['version']}_linux_#{node['serf']['arch']}.zip"
 


### PR DESCRIPTION
Somehow, the download URL to `serf` has changed.
We need to change the `serf` download URL.