### PR TITLE
[WIP] Remove unnecessary test.

### DIFF
--- a/site-cookbooks/growthforecast/test/integration/default/serverspec/prerequisites_spec.rb
+++ b/site-cookbooks/growthforecast/test/integration/default/serverspec/prerequisites_spec.rb
@@ -8,10 +8,6 @@ describe user('growth') do
   it { should have_login_shell '/bin/bash' }
 end
 
-describe package('nginx') do
-  it { should be_installed }
-end
-
 describe package('fonts-ipafont') do
   it { should be_installed }
 end


### PR DESCRIPTION
Since we build `nginx` manually, we do not use `apt` to install `nginx`.