### PR TITLE
[WIP] Modify `td-agent` configuration for `sensu`.

### DIFF
--- a/site-cookbooks/sensu-custom/files/default/processor_sensu-server.conf
+++ b/site-cookbooks/sensu-custom/files/default/processor_sensu-server.conf
@@ -17,7 +17,7 @@
       input_key message
       regexp info
       regexp handler output
-      exclude (handling|silenced|enough)
+      exclude (handling|silenced|enough|\[\])
       add_tag_prefix notification.danger
     </template>
   </store>


### PR DESCRIPTION
`sensu` starts to output the logs like this:

```
www19215ui: {"timestamp":"2016-02-21T23:09:03.259459+0900",
"level":"info", "message":"handler output", "handler":{"type":"pipe",
"mutator":"growthforecast-mutator", "command":"growthforecast-handler.rb",
"name":"growthforecast"}, "output":[]}
```

We will ignore this logs to be notified to `slack` by specifing "\[\]".