### PR TITLE
[WIP] Modify the flapping condition for `http://everun.club/`

### DIFF
--- a/site-cookbooks/sensu-custom/recipes/server_checks.rb
+++ b/site-cookbooks/sensu-custom/recipes/server_checks.rb
@@ -34,6 +34,7 @@ end
     handlers ['default']
     interval 60
     standalone true
+    additional(occurrences: 3)
   end
 end
 


### PR DESCRIPTION
Currently `sensu` sends alert notification when it detects 1 occurrence of
bad response time. But we have so many `sensu` alert notifications, so we
will change the flapping condition from 1 to 3.