### PR TITLE
[WIP] Modify `nginx` configuraition for `monit` monitoring.

### DIFF
--- a/site-cookbooks/nginx/recipes/setup.rb
+++ b/site-cookbooks/nginx/recipes/setup.rb
@@ -42,6 +42,8 @@ end
     group 'root'
     mode 0644
     action :create
+
+    notifies :restart, 'service[nginx]'
   end
 end
 

--- a/site-cookbooks/nginx/templates/default/default.erb
+++ b/site-cookbooks/nginx/templates/default/default.erb
@@ -5,3 +5,10 @@ server {
 
   return 444;
 }
+
+server {
+  listen 80;
+  server_name localhost;
+
+  return 200;
+}


### PR DESCRIPTION
Seems that `nginx` configuration for `localhost` returns 444.
This causes `monit` to detect `nginx`'s failure.

In order for `monit` to work properly,
modify `nginx` configuration for `localhost` to return 200.