### PR TITLE
[WIP] Support Ubuntu1604 for growthforecast.

### DIFF
--- a/site-cookbooks/growthforecast/.kitchen.yml
+++ b/site-cookbooks/growthforecast/.kitchen.yml
@@ -16,6 +16,9 @@ platforms:
   - name: ubuntu-14.04
     driver_config:
       image: kazu634:ubuntu1404
+  - name: ubuntu-16.04
+    driver_config:
+      image: kazu634:ubuntu1604
 
 suites:
   - name: default


### PR DESCRIPTION
This pull request will support Ubuntu1604 for `growthforecast`.