### PR TITLE
[WIP] Fix the problem of not successfully unzipping:

### DIFF
--- a/site-cookbooks/serf/recipes/install.rb
+++ b/site-cookbooks/serf/recipes/install.rb
@@ -21,7 +21,6 @@ end
 
 # Unzip serf binary
 execute 'unzip serf binary' do
-  user node['serf']['user']
   cwd '/opt/serf/bin/'
 
   # -q = quiet, -o = overwrite existing files


### PR DESCRIPTION
Since `Chef` changed the temporary directory to <Chef user's home directory>/chef-solo/local-mode-cache/cache,
unzipping as the other user cannot work.

So, this commit will use `root` user to execute `unzip` command.
Thus, fixing the problem of not successfully unzipping.