### PR TITLE
[WIP] Add `td-agent` user to the `adm` group.

### DIFF
--- a/site-cookbooks/fluentd-custom/recipes/td_agent.rb
+++ b/site-cookbooks/fluentd-custom/recipes/td_agent.rb
@@ -42,6 +42,12 @@ cookbook_file '/etc/monit/conf.d/td-agent.conf' do
   notifies :restart, 'service[monit]'
 end
 
+group 'adm' do
+  action :modify
+  members 'td-agent'
+  append true
+end
+
 ###################
 # The Client part #
 ###################

--- a/site-cookbooks/fluentd-custom/test/integration/default/serverspec/td_agent_spec.rb
+++ b/site-cookbooks/fluentd-custom/test/integration/default/serverspec/td_agent_spec.rb
@@ -41,3 +41,7 @@ describe file('/etc/monit/conf.d/td-agent.conf') do
 
   its(:md5sum) { should eq 'b540eae27614f6e3321e4c838dbda039' }
 end
+
+describe user('td-agent') do
+  it { should belong_to_group 'adm' }
+end

--- a/site-cookbooks/fluentd-custom/test/integration/server/serverspec/td_agent_spec.rb
+++ b/site-cookbooks/fluentd-custom/test/integration/server/serverspec/td_agent_spec.rb
@@ -57,3 +57,7 @@ describe iptables do
   it { should have_rule '-A FWR -p tcp -m tcp --dport 24224 -j ACCEPT' }
   it { should have_rule '-A FWR -p udp -m udp --dport 24224 -j ACCEPT' }
 end
+
+describe user('td-agent') do
+  it { should belong_to_group 'adm' }
+end


### PR DESCRIPTION
Since `td-agent`, by default, cannot monitor `/var/log/monit.log`,
we are going to add `td-agent` user to the `adm` group.