### PR TITLE
[WIP] Explicitly rotate the `cron-apt` log files.

### DIFF
--- a/site-cookbooks/base/recipes/cron_apt.rb
+++ b/site-cookbooks/base/recipes/cron_apt.rb
@@ -16,7 +16,7 @@ cookbook_file '/etc/cron-apt/config' do
 
   owner 'root'
   group 'root'
-  mode 0644
+  mode 0o644
 end
 
 cookbook_file '/etc/cron-apt/action.d/3-download' do
@@ -24,7 +24,7 @@ cookbook_file '/etc/cron-apt/action.d/3-download' do
 
   owner 'root'
   group 'root'
-  mode 0644
+  mode 0o644
 end
 
 script 'Generate /etc/apt/security.sources.list' do
@@ -38,4 +38,29 @@ script 'Generate /etc/apt/security.sources.list' do
   EOH
 
   not_if 'test -s /etc/apt/security.sources.list'
+end
+
+script 'Put dummy log files' do
+  interpreter 'bash'
+
+  user 'root'
+  group 'root'
+
+  code <<-EOH
+    touch /var/log/cron-apt/log
+    echo foo | tee -a /var/log/cron-apt/log
+  EOH
+
+  not_if { File.exist?('/var/log/cron-apt/log') }
+end
+
+script 'Explicitly rotate the log file' do
+  interpreter 'bash'
+
+  user 'root'
+  group 'root'
+
+  code <<-EOH
+    /usr/sbin/logrotate -f /etc/logrotate.d/cron-apt
+  EOH
 end

--- a/site-cookbooks/base/test/integration/default/serverspec/cron_apt_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/cron_apt_spec.rb
@@ -1,6 +1,6 @@
 require 'serverspec'
 
-set :backend,  :exec
+set :backend, :exec
 
 describe package('cron-apt') do
   it { should be_installed }
@@ -32,4 +32,12 @@ describe file('/etc/apt/security.sources.list') do
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
   it { should be_mode 644 }
+end
+
+describe file('/var/log/cron-apt/log') do
+  it { should be_file }
+
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'adm' }
+  it { should be_mode 640 }
 end


### PR DESCRIPTION
After rotating `cron-apt` log files, `td-agent` can monitor the
`cron-apt` log files.

This pull request will explicitly rotate the `cron-apt` log files.