### PR TITLE
[WIP] Use `apt` command, instead of `aptitude` command.

### DIFF
--- a/site-cookbooks/base/files/default/3-download
+++ b/site-cookbooks/base/files/default/3-download
@@ -1,2 +1,2 @@
 autoclean -y
-safe-upgrade -y -o APT::Get::Show-Upgraded=true
+upgrade -y -o APT::Get::Show-Upgraded=true

--- a/site-cookbooks/base/files/default/config
+++ b/site-cookbooks/base/files/default/config
@@ -6,6 +6,6 @@ DEBUG="verbose"
 
 MAILON=""
 
-APTCOMMAND=/usr/bin/aptitude
+APTCOMMAND=/usr/bin/apt
 
 OPTIONS="-o quiet=1 -o Dir::Etc::SourceList=/etc/apt/security.sources.list"

--- a/site-cookbooks/base/test/integration/default/serverspec/cron_apt_spec.rb
+++ b/site-cookbooks/base/test/integration/default/serverspec/cron_apt_spec.rb
@@ -13,7 +13,7 @@ describe file('/etc/cron-apt/config') do
   it { should be_grouped_into 'root' }
   it { should be_mode 644 }
 
-  its(:md5sum) { should eq '667914d673b618b4f45b3692a41f96e8' }
+  its(:md5sum) { should eq 'd15e94359cbd9570909f4a0ba23ee11a' }
 end
 
 describe file('/etc/cron-apt/action.d/3-download') do
@@ -23,7 +23,7 @@ describe file('/etc/cron-apt/action.d/3-download') do
   it { should be_grouped_into 'root' }
   it { should be_mode 644 }
 
-  its(:md5sum) { should eq 'ff89c62ee7ce7724d055927332be8433' }
+  its(:md5sum) { should eq 'cab15cb06be6c0d5bcc3625f2a59b6a3' }
 end
 
 describe file('/etc/apt/security.sources.list') do


### PR DESCRIPTION
When `cron-apt` tries to update & upgrade, we are now using `aptitude`
command. However, `aptitude` command is no longer available since Ubuntu
16.04.

Thus, use `apt` command, instead of `aptitude` command.