### PR TITLE
[WIP] Monitor `/var/run/reboot-require`.

### DIFF
--- a/site-cookbooks/consul/files/default/check-reboot-required.json
+++ b/site-cookbooks/consul/files/default/check-reboot-required.json
@@ -1,0 +1,9 @@
+{
+  "check": {
+    "id": "reboot-required",
+    "name": "Check for Reboot Required",
+    "script": "/usr/lib/nagios/plugins/check_file.sh /var/run/reboot-required",
+    "interval": "86400s",
+    "timeout": "10s"
+  }
+}

--- a/site-cookbooks/consul/files/default/check_file
+++ b/site-cookbooks/consul/files/default/check_file
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TARGET=$1
+
+if [ -f ${TARGET} ]; then
+  exit 1
+fi
+
+exit 0

--- a/site-cookbooks/consul/recipes/monitoring.rb
+++ b/site-cookbooks/consul/recipes/monitoring.rb
@@ -14,8 +14,18 @@ package 'nagios-plugins' do
   options '--no-install-recommends'
 end
 
+# Deploy the check-file script:
+cookbook_file '/usr/lib/nagios/plugins/check_file' do
+  source 'check_file'
+  owner 'root'
+  group 'root'
+  mode 0o555
+
+  notifies :reload, 'service[consul]'
+end
+
 # Deploy `consul` monitoring config file:
-%w(disk load ssh swap).each do |target|
+%w(disk load ssh swap reboot-required).each do |target|
   cookbook_file "/etc/consul.d/check-#{target}.json" do
     owner node['consul']['user']
     group node['consul']['group']

--- a/site-cookbooks/consul/test/integration/default/serverspec/monitoring_spec.rb
+++ b/site-cookbooks/consul/test/integration/default/serverspec/monitoring_spec.rb
@@ -6,7 +6,15 @@ describe package('nagios-plugins') do
   it { should be_installed }
 end
 
-%w(disk load ssh swap).each do |target|
+describe file('/usr/lib/nagios/plugins/check_file') do
+  it { should be_file }
+
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 555 }
+end
+
+%w(disk load ssh swap reboot-required).each do |target|
   describe file("/etc/consul.d/check-#{target}.json") do
     it { should be_owned_by '_consul' }
     it { should be_grouped_into '_consul' }

--- a/site-cookbooks/consul/test/integration/server/serverspec/monitoring_spec.rb
+++ b/site-cookbooks/consul/test/integration/server/serverspec/monitoring_spec.rb
@@ -6,7 +6,15 @@ describe package('nagios-plugins') do
   it { should be_installed }
 end
 
-%w(disk load ssh swap).each do |target|
+describe file('/usr/lib/nagios/plugins/check_file') do
+  it { should be_file }
+
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 555 }
+end
+
+%w(disk load ssh swap reboot-required).each do |target|
   describe file("/etc/consul.d/check-#{target}.json") do
     it { should be_owned_by '_consul' }
     it { should be_grouped_into '_consul' }


### PR DESCRIPTION
This pull request will use `consul` to monitor
`/var/run/reboot-required`.

`/var/run/reboot-required` exists, when the reboot is required.