### PR TITLE
[WIP] Modify the shell script name typo

### DIFF
--- a/site-cookbooks/consul/files/default/check-reboot-required.json
+++ b/site-cookbooks/consul/files/default/check-reboot-required.json
@@ -2,7 +2,7 @@
   "check": {
     "id": "reboot-required",
     "name": "Check for Reboot Required",
-    "script": "/usr/lib/nagios/plugins/check_file.sh /var/run/reboot-required",
+    "script": "/usr/lib/nagios/plugins/check_file /var/run/reboot-required",
     "interval": "86400s",
     "timeout": "10s"
   }


### PR DESCRIPTION
This pull request will modify the shell script name typo for monitoring
`/var/run/reboot-required`.