### PR TITLE
[WIP] Use `monit` to monitor `consul`

### DIFF
--- a/site-cookbooks/consul/Berksfile
+++ b/site-cookbooks/consul/Berksfile
@@ -1,3 +1,4 @@
 site :opscode
 
+cookbook 'monit', path: '../monit'
 metadata

--- a/site-cookbooks/consul/attributes/default.rb
+++ b/site-cookbooks/consul/attributes/default.rb
@@ -1,6 +1,3 @@
-default['consul']['user']  = '_consul'
-default['consul']['group'] = '_consul'
-
 default['consul']['base_binary_url'] = 'https://releases.hashicorp.com/consul/'
 default['consul']['arch']            = \
   node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : '386'

--- a/site-cookbooks/consul/files/default/consul
+++ b/site-cookbooks/consul/files/default/consul
@@ -1,2 +1,2 @@
 GOMAXPROCS=2
-OPTIONS=""
+OPTIONS="-pid-file /var/run/consul.pid"

--- a/site-cookbooks/consul/files/default/consul.conf
+++ b/site-cookbooks/consul/files/default/consul.conf
@@ -1,0 +1,10 @@
+check process consul
+  with pidfile /var/run/consul.pid
+  start program = "/bin/systemctl start consul.service"
+  stop program = "/bin/systemctl stop consul.service"
+
+  if failed
+    host localhost
+    port 8500
+    protocol HTTP
+  then restart

--- a/site-cookbooks/consul/files/default/consul.service
+++ b/site-cookbooks/consul/files/default/consul.service
@@ -1,3 +1,4 @@
+
 [Unit]
 Description=consul agent
 Requires=network-online.target
@@ -10,8 +11,8 @@ Restart=on-failure
 ExecStart=/usr/bin/consul agent $OPTIONS -config-dir=/etc/consul.d
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
-User=_consul
-Group=_consul
+User=root
+Group=root
 
 [Install]
 WantedBy=multi-user.target

--- a/site-cookbooks/consul/metadata.rb
+++ b/site-cookbooks/consul/metadata.rb
@@ -7,3 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
 depends 'iptables'
+depends 'monit'

--- a/site-cookbooks/consul/recipes/install.rb
+++ b/site-cookbooks/consul/recipes/install.rb
@@ -35,8 +35,8 @@ end
 remote_file node['consul']['tmp_path'] do
   source download_url
 
-  owner node['consul']['user']
-  group node['consul']['group']
+  owner 'root'
+  group 'root'
   mode 0o0644
 
   action :create_if_missing
@@ -54,8 +54,8 @@ execute 'unzip consul binary' do
 end
 
 file '/opt/consul/bin/consul' do
-  owner node['consul']['user']
-  group node['consul']['group']
+  owner 'root'
+  group 'root'
 
   mode 0o0755
 end

--- a/site-cookbooks/consul/recipes/monitoring.rb
+++ b/site-cookbooks/consul/recipes/monitoring.rb
@@ -27,8 +27,8 @@ end
 # Deploy `consul` monitoring config file:
 %w(disk load ssh swap reboot-required).each do |target|
   cookbook_file "/etc/consul.d/check-#{target}.json" do
-    owner node['consul']['user']
-    group node['consul']['group']
+    owner 'root'
+    group 'root'
 
     mode 0o644
 

--- a/site-cookbooks/consul/recipes/prerequisites.rb
+++ b/site-cookbooks/consul/recipes/prerequisites.rb
@@ -17,22 +17,11 @@ package 'dnsmasq' do
   action :install
 end
 
-# Create consul user/group
-group node['consul']['group'] do
-  action :create
-end
-
-user node['consul']['user'] do
-  gid node['consul']['group']
-  system true
-  home '/nonexistent'
-end
-
 # `consul`-related paths:
 %w(/etc/consul.d /var/opt/consul /opt/consul/bin).each do |d|
   directory d do
-    owner node['consul']['user']
-    group node['consul']['group']
+    owner 'root'
+    group 'root'
 
     mode 0o755
 

--- a/site-cookbooks/consul/recipes/setup.rb
+++ b/site-cookbooks/consul/recipes/setup.rb
@@ -65,6 +65,18 @@ cookbook_file '/etc/consul.d/service-consul.json' do
   notifies :restart, 'service[consul]'
 end
 
+# Monit integration:
+include_recipe 'monit'
+
+cookbook_file '/etc/monit/conf.d/consul.conf' do
+  owner 'root'
+  group 'root'
+
+  mode 0o644
+
+  notifies :restart, 'service[monit]'
+end
+
 # Start `consul` service
 service 'consul' do
   supports status: true, restart: true, reload: true

--- a/site-cookbooks/consul/recipes/setup.rb
+++ b/site-cookbooks/consul/recipes/setup.rb
@@ -48,16 +48,16 @@ end
 template '/etc/consul.d/config.json' do
   source 'consul.json.erb'
 
-  owner node['consul']['user']
-  group node['consul']['group']
+  owner 'root'
+  group 'root'
   mode 0o644
 
   notifies :restart, 'service[consul]'
 end
 
 cookbook_file '/etc/consul.d/service-consul.json' do
-  owner node['consul']['user']
-  group node['consul']['group']
+  owner 'root'
+  group 'root'
 
   mode 0o644
 

--- a/site-cookbooks/consul/test/integration/default/serverspec/install_spec.rb
+++ b/site-cookbooks/consul/test/integration/default/serverspec/install_spec.rb
@@ -3,8 +3,8 @@ require 'serverspec'
 set :backend, :exec
 
 describe file('/opt/consul/bin/consul') do
-  it { should be_owned_by '_consul' }
-  it { should be_grouped_into '_consul' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
   it { should be_mode 755 }
 end
 

--- a/site-cookbooks/consul/test/integration/default/serverspec/monitoring_spec.rb
+++ b/site-cookbooks/consul/test/integration/default/serverspec/monitoring_spec.rb
@@ -16,8 +16,8 @@ end
 
 %w(disk load ssh swap reboot-required).each do |target|
   describe file("/etc/consul.d/check-#{target}.json") do
-    it { should be_owned_by '_consul' }
-    it { should be_grouped_into '_consul' }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
     it { should be_mode 644 }
   end
 end

--- a/site-cookbooks/consul/test/integration/default/serverspec/prerequisites_spec.rb
+++ b/site-cookbooks/consul/test/integration/default/serverspec/prerequisites_spec.rb
@@ -10,20 +10,10 @@ describe package('dnsmasq') do
   it { should be_installed }
 end
 
-describe group('_consul') do
-  it { should exist }
-end
-
-describe user('_consul') do
-  it { should exist }
-  it { should belong_to_group '_consul' }
-  it { should have_home_directory '/nonexistent' }
-end
-
 %w(/etc/consul.d /var/opt/consul /opt/consul/bin).each do |d|
   describe file(d) do
     it { should be_directory }
-    it { should be_owned_by '_consul' }
+    it { should be_owned_by 'root' }
     it { should be_mode 755 }
   end
 end

--- a/site-cookbooks/consul/test/integration/default/serverspec/setup_spec.rb
+++ b/site-cookbooks/consul/test/integration/default/serverspec/setup_spec.rb
@@ -21,8 +21,14 @@ describe file('/etc/rsyslog.d/22-consul.conf') do
 end
 
 describe file('/etc/consul.d/config.json') do
-  it { should be_owned_by '_consul' }
-  it { should be_grouped_into '_consul' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+end
+
+describe file('/etc/monit/conf.d/consul.conf') do
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
   it { should be_mode 644 }
 end
 

--- a/site-cookbooks/consul/test/integration/server/serverspec/install_spec.rb
+++ b/site-cookbooks/consul/test/integration/server/serverspec/install_spec.rb
@@ -3,8 +3,8 @@ require 'serverspec'
 set :backend, :exec
 
 describe file('/opt/consul/bin/consul') do
-  it { should be_owned_by '_consul' }
-  it { should be_grouped_into '_consul' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
   it { should be_mode 755 }
 end
 

--- a/site-cookbooks/consul/test/integration/server/serverspec/monitoring_spec.rb
+++ b/site-cookbooks/consul/test/integration/server/serverspec/monitoring_spec.rb
@@ -16,8 +16,8 @@ end
 
 %w(disk load ssh swap reboot-required).each do |target|
   describe file("/etc/consul.d/check-#{target}.json") do
-    it { should be_owned_by '_consul' }
-    it { should be_grouped_into '_consul' }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
     it { should be_mode 644 }
   end
 end

--- a/site-cookbooks/consul/test/integration/server/serverspec/prerequisites_spec.rb
+++ b/site-cookbooks/consul/test/integration/server/serverspec/prerequisites_spec.rb
@@ -10,20 +10,10 @@ describe package('dnsmasq') do
   it { should be_installed }
 end
 
-describe group('_consul') do
-  it { should exist }
-end
-
-describe user('_consul') do
-  it { should exist }
-  it { should belong_to_group '_consul' }
-  it { should have_home_directory '/nonexistent' }
-end
-
 %w(/etc/consul.d /var/opt/consul /opt/consul/bin).each do |d|
   describe file(d) do
     it { should be_directory }
-    it { should be_owned_by '_consul' }
+    it { should be_owned_by 'root' }
     it { should be_mode 755 }
   end
 end

--- a/site-cookbooks/consul/test/integration/server/serverspec/setup_spec.rb
+++ b/site-cookbooks/consul/test/integration/server/serverspec/setup_spec.rb
@@ -21,14 +21,20 @@ describe file('/etc/rsyslog.d/22-consul.conf') do
 end
 
 describe file('/etc/consul.d/config.json') do
-  it { should be_owned_by '_consul' }
-  it { should be_grouped_into '_consul' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
   it { should be_mode 644 }
 end
 
 describe file('/etc/consul.d/service-consul.json') do
-  it { should be_owned_by '_consul' }
-  it { should be_grouped_into '_consul' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+end
+
+describe file('/etc/monit/conf.d/consul.conf') do
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
   it { should be_mode 644 }
 end
 


### PR DESCRIPTION
Sometimes `consul` will not restart properly.

So, use `monit` to monitor `consul` and start up again when some problem
happens.