### PR TITLE
[WIP] Monitoring Enhancement 20170523.

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/processor.conf
+++ b/site-cookbooks/fluentd-custom/files/default/processor.conf
@@ -82,7 +82,7 @@
 
   <filter td_agent>
     @type grep
-    exclude1 message (\[info\]|parameter '.*' in|suppressed same stacktrace|loop\.rb|in_tail\.rb)
+    exclude1 message (\[info\]|parameter '.*' in|suppressed same stacktrace|loop\.rb|in_tail\.rb|06:25 )
     regexp1 message \[(warn|error)\]
   </filter>
 


### PR DESCRIPTION
Do not notify, if the logs containing "06:25"
from `/var/log/td-agent/td-agent.log`.

Since `logrotated` will rotate the log files ever 06:25 everyday,
`td-agent` will output "permission error".

This pull request will filter out these logs.