### PR TITLE
[WIP] Change the `fluentd` configuration for `consul` log files.

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/forwarder_consul.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_consul.conf
@@ -2,14 +2,15 @@
   type tail
   path /var/log/supervisor/consul.log
   pos_file /var/log/td-agent/consul.pos
-  format syslog
+  format /^(    (?<time>[0-9/]+ [0-9:]+) (?<message>.*$)|(?<message>.*))/
+  time_format %Y/%m/%d %H:%M:%S
   tag consul
 </source>
 
 <filter consul>
   @type record_transformer
   <record>
-    message ${host}: ${record["message"]}
+    message ${hostname}: ${record["message"]}
   </record>
 </filter>
 


### PR DESCRIPTION
Since we no longer use `rsyslog`,
change the `fluentd` configuration as follows:

```
<source>
  type tail
  path /var/log/supervisor/consul.log
  pos_file /var/log/td-agent/consul.pos
  format /^(    (?<time>[0-9/]+ [0-9:]+)
(?<message>.*$)|(?<message>.*))/
  time_format %Y/%m/%d %H:%M:%S
  tag consul
</source>
```