### PR TITLE
[WIP] Filter out the `logrotat` error messages from `fluentd` logs.

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/processor.conf
+++ b/site-cookbooks/fluentd-custom/files/default/processor.conf
@@ -82,7 +82,7 @@
 
   <filter td_agent>
     @type grep
-    exclude1 message (\[info\]|parameter '.*' in|suppressed same stacktrace|loop\.rb|in_tail\.rb|06:25 )
+    exclude1 message (\[info\]|parameter '.*' in|suppressed same stacktrace|loop\.rb|in_tail\.rb| 06:25)
     regexp1 message \[(warn|error)\]
   </filter>
 


### PR DESCRIPTION
This pull request will filter out the `logrotate` error messages from
the `fluentd` log files.