### PR TITLE
[WIP] Notify `apt-mirror` logs to `Slack` #ops.

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/processor.conf
+++ b/site-cookbooks/fluentd-custom/files/default/processor.conf
@@ -95,4 +95,9 @@
     @type relabel
     @label @notify
   </match>
+
+  <match apt-mirror.**>
+    @type relabel
+    @label @notify
+  </match>
 </label>

--- a/site-cookbooks/fluentd-custom/templates/default/watcher.erb
+++ b/site-cookbooks/fluentd-custom/templates/default/watcher.erb
@@ -39,6 +39,26 @@
     </store>
   </match>
 
+  <match apt-mirror.**>
+    @type copy
+
+    <store>
+      @type slack
+      webhook_url <%= @webhook_url %>
+      channel %23ops
+      username kazu-chan
+      color good
+      icon_emoji :honeybee:
+      message_keys log
+      flush_interval 60s
+    </store>
+
+    <store>
+      @type file
+      path /tmp/notify-apt-mirror.log
+    </store>
+  </match>
+
   <match **>
     @type copy
 


### PR DESCRIPTION
This pull request will change the `apt-mirror` notification target
from #app to #ops.