### PR TITLE
[WIP] Hotfix for solving the fluentd not notifying issue

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/processor.conf
+++ b/site-cookbooks/fluentd-custom/files/default/processor.conf
@@ -6,6 +6,11 @@
 </label>
 
 <label @received>
+  <match nginx>
+    @type relabel
+    @label @s3_upload
+  </match>
+
   <match **>
     @type copy
 

--- a/site-cookbooks/fluentd-custom/recipes/td_agent.rb
+++ b/site-cookbooks/fluentd-custom/recipes/td_agent.rb
@@ -68,6 +68,8 @@ cookbook_file '/etc/td-agent/conf.d/forwarder.conf' do
 
   mode 0o644
 
+  not_if { node['td_agent']['forward'] }
+
   notifies :restart, 'service[td-agent]'
 end
 

--- a/site-cookbooks/fluentd-custom/templates/default/processor_nginx.conf.erb
+++ b/site-cookbooks/fluentd-custom/templates/default/processor_nginx.conf.erb
@@ -2,7 +2,7 @@
 # Receive nginx logs #
 ######################
 
-<label @process>
+<label @s3_upload>
   <match nginx>
     @type copy
 


### PR DESCRIPTION
`td-agent` version 0.12.35 somehow does not allow us to write the same
label configuration in separate configuration files.

So, this will modify the configuration files not to specify the same
labels in separate configuration files.