### PR TITLE
[WIP] Filter the unnecessary character conversion message:

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/processor.conf
+++ b/site-cookbooks/fluentd-custom/files/default/processor.conf
@@ -92,7 +92,7 @@
 
   <filter td_agent>
     @type grep
-    exclude1 message (\[info\]|parameter '.*' in|suppressed same stacktrace|loop\.rb|in_tail\.rb| 06:25)
+    exclude1 message (\[info\]|parameter '.*' in|suppressed same stacktrace|loop\.rb|in_tail\.rb| 06:25|from ASCII-8BIT to UTF-8)
     regexp1 message \[(warn|error)\]
   </filter>
 


### PR DESCRIPTION
This pull request will filter out the following message:

```
2017-07-24 20:42:36 +0900 [warn]: out_slack: to_json `{:attachments=>[{:fallback=>"category: pocket, url: https://number333.org/2017/07/22/mac-apps/, title: \u6BCE\u65E5\u5FC3\u5730\u826F\u304F\u4F5C\u696D\u3059\u308B\u305F\u3081\u306E\u50D5\u306E\u5FC5\u9808Mac\u30A2\u30D7\u30EA16\u500B\ncategory: pocket, url: http://www.ashi-tano.jp/?p=11844, title: \u611B\u3057\u3066\u6B62\u307E\u306A\u3044\u6587\u623F\u517713\u9078\u3010\u79C1\u304C\u624B\u653E\u305B\u306A\u3044\u6587\u623F\u5177\u30FB\u30AC\u30B8\u30A7\u30C3\u30C8\u3011\n", :text=>"category: pocket, url: https://number333.org/2017/07/22/mac-apps/, title: \u6BCE\u65E5\u5FC3\u5730\u826F\u304F\u4F5C\u696D\u3059\u308B\u305F\u3081\u306E\u50D5\u306E\u5FC5\u9808Mac\u30A2\u30D7\u30EA16\u500B\ncategory: pocket, url: http://www.ashi-tano.jp/?p=11844, title: \u611B\u3057\u3066\u6B62\u307E\u306A\u3044\u6587\u623F\u517713\u9078\u3010\u79C1\u304C\u624B\u653E\u305B\u306A\u3044\u6587\u623F\u5177\u30FB\u30AC\u30B8\u30A7\u30C3\u30C8\u3011\n", :color=>"good", :mrkdwn_in=>["text", "fields"]}], :channel=>"#apps", :username=>"kazu-chan", :icon_emoji=>":honeybee:", :mrkdwn=>true, :link_names=>true}` failed. retry after scrub!. "\xE6" from ASCII-8BIT
```