### PR TITLE
[WIP] Specify `"enable_script_checks": true` to `consul` config.

### DIFF
--- a/site-cookbooks/consul/templates/default/consul.json.erb
+++ b/site-cookbooks/consul/templates/default/consul.json.erb
@@ -15,6 +15,7 @@
   "data_dir": "/var/opt/consul",
   "log_level": "INFO",
   "enable_syslog": false,
+  "enable_script_checks": true,
   "rejoin_after_leave": true,
   "retry_join": <%= node['consul']['manager_hosts'] %>,
   "encrypt": "LPKrNBQZnJIc8tJpViI4ug==",


### PR DESCRIPTION
This pull-request will specify `"enable_script_checks": true`.
Somehow, `consul` introduced this option to enable the script checking.