### PR TITLE
[WIP] Improve the Let's Encrypt Integration.

### DIFF
--- a/site-cookbooks/blog/recipes/nginx.rb
+++ b/site-cookbooks/blog/recipes/nginx.rb
@@ -16,6 +16,11 @@ template '/etc/nginx/sites-available/blog' do
   variables fqdn: node['blog']['FQDN']
 end
 
+link '/etc/nginx/sites-enabled/blog' do
+  to '/etc/nginx/sites-available/blog'
+  notifies :restart, 'service[nginx]'
+end
+
 directory '/var/www/blog' do
   owner 'www-data'
   group 'webadm'

--- a/site-cookbooks/blog/recipes/ssl.rb
+++ b/site-cookbooks/blog/recipes/ssl.rb
@@ -40,33 +40,4 @@ if node['blog']['production']
     group 'root'
     creates "/etc/letsencrypt/live/#{node['blog']['FQDN']}/ticket.key"
   end
-
-  directory '/home/webadm/bin' do
-    owner 'webadm'
-    group 'webadm'
-    mode 0755
-  end
-
-  template '/home/webadm/bin/ssl_renewal.sh' do
-    source 'ssl_renewal.sh'
-    owner 'webadm'
-    group 'webadm'
-    mode 0755
-
-    variables fqdn: node['blog']['FQDN']
-  end
-
-  template '/etc/cron.d/ssl' do
-    source 'ssl.crontab'
-    owner 'root'
-    group 'root'
-    mode 0644
-
-    variables fqdn: node['blog']['FQDN']
-  end
-
-  link '/etc/nginx/sites-enabled/blog' do
-    to '/etc/nginx/sites-available/blog'
-    notifies :restart, 'service[nginx]'
-  end
 end

--- a/site-cookbooks/blog/templates/default/blog.crontab
+++ b/site-cookbooks/blog/templates/default/blog.crontab
@@ -1,1 +1,2 @@
 @reboot webadm cp -pr /home/webadm/works/public/* /var/www/blog/
+12 3 * * * root openssl rand 48 > /etc/letsencrypt/live/<%= @fqdn %>/ticket.key

--- a/site-cookbooks/blog/templates/default/ssl.crontab
+++ b/site-cookbooks/blog/templates/default/ssl.crontab
@@ -1,2 +1,0 @@
-2 2 25 */1 * root /home/webadm/bin/ssl_renewal.sh
-12 3 * * * root openssl rand 48 > /etc/letsencrypt/live/<%= @fqdn %>/ticket.key

--- a/site-cookbooks/nginx/recipes/letsencrypt.rb
+++ b/site-cookbooks/nginx/recipes/letsencrypt.rb
@@ -19,3 +19,23 @@ git '/home/webadm/letsencrypt' do
   user 'webadm'
   group 'webadm'
 end
+
+directory '/home/webadm/bin' do
+  owner 'webadm'
+  group 'webadm'
+  mode 0755
+end
+
+template '/home/webadm/bin/ssl_renewal.sh' do
+  source 'ssl_renewal.sh'
+  owner 'webadm'
+  group 'webadm'
+  mode 0755
+end
+
+template '/etc/cron.d/ssl' do
+  source 'ssl.crontab'
+  owner 'root'
+  group 'root'
+  mode 0644
+end

--- a/site-cookbooks/nginx/recipes/letsencrypt.rb
+++ b/site-cookbooks/nginx/recipes/letsencrypt.rb
@@ -14,7 +14,7 @@ package 'git' do
 end
 
 git '/home/webadm/letsencrypt' do
-  repository 'https://github.com/letsencrypt/letsencrypt'
+  repository 'https://github.com/certbot/certbot'
   action :sync
   user 'webadm'
   group 'webadm'

--- a/site-cookbooks/nginx/templates/default/ssl.crontab
+++ b/site-cookbooks/nginx/templates/default/ssl.crontab
@@ -1,0 +1,1 @@
+2 2 25 */1 * root /home/webadm/bin/ssl_renewal.sh

--- a/site-cookbooks/nginx/templates/default/ssl_renewal.sh
+++ b/site-cookbooks/nginx/templates/default/ssl_renewal.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Preparation for maintenance:
+rm -f /etc/nginx/sites-enabled/*
+ln -s /etc/nginx/sites-available/maintenance /etc/nginx/sites-enabled/maintenance
+
+# Start maintenance:
+touch /tmp/maintenance
+
+# Reload `nginx` configuration:
+service nginx reload
+
+# Renewal SSL certificate:
+/home/webadm/letsencrypt/certbot-auto renew
+
+sleep 5
+
+# Stop maintenance:
+rm /tmp/maintenance
+
+# Preparation for normal operation:
+rm -f /etc/nginx/sites-enabled/maintenance
+
+for conf in `find /etc/nginx/sites-available -maxdepth 1 -type f | grep -v maintenance`; do
+  ln -s ${conf} /etc/nginx/sites-enabled/${conf/\/etc\/nginx\/sites-available\//}
+done
+
+# Reload `nginx` configuration:
+service nginx reload
+
+exit 0

--- a/site-cookbooks/wekan-nginx/recipes/nginx.rb
+++ b/site-cookbooks/wekan-nginx/recipes/nginx.rb
@@ -16,7 +16,7 @@ template '/etc/nginx/sites-available/wekan-nginx' do
   variables fqdn: node['wekan-nginx']['FQDN']
 end
 
-link '/etc/nginx/sites-enabled/wekan' do
-  to '/etc/nginx/sites-available/wekan'
+link '/etc/nginx/sites-enabled/wekan-nginx' do
+  to '/etc/nginx/sites-available/wekan-nginx'
   notifies :restart, 'service[nginx]'
 end

--- a/site-cookbooks/wekan-nginx/recipes/nginx.rb
+++ b/site-cookbooks/wekan-nginx/recipes/nginx.rb
@@ -20,3 +20,12 @@ link '/etc/nginx/sites-enabled/wekan-nginx' do
   to '/etc/nginx/sites-available/wekan-nginx'
   notifies :restart, 'service[nginx]'
 end
+
+template '/etc/cron.d/wekan' do
+  source 'wekan.crontab'
+  owner 'root'
+  group 'root'
+  mode 0644
+
+  variables fqdn: node['wekan-nginx']['FQDN']
+end

--- a/site-cookbooks/wekan-nginx/recipes/ssl.rb
+++ b/site-cookbooks/wekan-nginx/recipes/ssl.rb
@@ -18,7 +18,7 @@ if node['wekan-nginx']['production']
     # Apply
     systemctl restart nginx.service
 
-    ./certbot-auto certonly --webroot -d #{node['wekan-nginx']['FQDN']} --webroot-path /usr/share/nginx/html/ --email simoom634@yahoo.co.jp --agree-tos
+    /home/webadm/letsencrypt/certbot-auto certonly --webroot -d #{node['wekan-nginx']['FQDN']} --webroot-path /usr/share/nginx/html/ --email simoom634@yahoo.co.jp --agree-tos -n
 
     # Delete config
     rm -f /etc/nginx/sites-enabled/maintenance

--- a/site-cookbooks/wekan-nginx/recipes/ssl.rb
+++ b/site-cookbooks/wekan-nginx/recipes/ssl.rb
@@ -55,28 +55,4 @@ if node['wekan-nginx']['production']
     group 'root'
     creates "/etc/letsencrypt/live/#{node['wekan-nginx']['FQDN']}/ticket.key"
   end
-
-  directory '/home/webadm/bin' do
-    owner 'webadm'
-    group 'webadm'
-    mode 0755
-  end
-
-  template '/home/webadm/bin/ssl_renewal.sh' do
-    source 'ssl_renewal.sh'
-    owner 'webadm'
-    group 'webadm'
-    mode 0755
-
-    variables fqdn: node['wekan-nginx']['FQDN']
-  end
-
-  template '/etc/cron.d/ssl' do
-    source 'ssl.crontab'
-    owner 'root'
-    group 'root'
-    mode 0644
-
-    variables fqdn: node['wekan-nginx']['FQDN']
-  end
 end

--- a/site-cookbooks/wekan-nginx/templates/default/wekan.crontab
+++ b/site-cookbooks/wekan-nginx/templates/default/wekan.crontab
@@ -1,2 +1,1 @@
-2 2 25 */1 * root /home/webadm/bin/ssl_renewal.sh
 12 3 * * * root openssl rand 48 > /etc/letsencrypt/live/<%= @fqdn %>/ticket.key


### PR DESCRIPTION
- Change the Let's Encrypt Github URL
- Place the Cron setting to renew the SSL Certificates to `nginx` cookbook.