### PR TITLE
[WIP] Cover `td-agent`'s broken backward compatibility:

### DIFF
--- a/site-cookbooks/fluentd-custom/files/default/forwarder.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder.conf
@@ -6,7 +6,7 @@
       @type forward
       send_timeout 60s
       recover_wait 10s
-      heartbeat_type tcp
+      transport tcp
       heartbeat_interval 1s
       phi_threshold 16
       hard_timeout 60s

--- a/site-cookbooks/fluentd-custom/files/default/forwarder_aptitude.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_aptitude.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   path /var/log/apt/history.log
   pos_file /var/log/td-agent/aptitude.pos
   format none

--- a/site-cookbooks/fluentd-custom/files/default/forwarder_auth.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_auth.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   path /var/log/auth.log
   pos_file /var/log/td-agent/auth.pos
   format syslog
@@ -9,13 +9,17 @@
 <filter auth>
   @type record_transformer
   <record>
-    message ${host}: ${record["message"]}
+    message ${hostname}: ${record["message"]}
   </record>
 </filter>
 
 <filter auth>
   @type grep
-  exclude1 message (CRON|Did not receive identification string from|sudo|pam_unix|seat|Removed session|Received disconnect|New session)
+
+  <exclude>
+    key message
+    pattern (CRON|Did not receive identification string from|sudo|pam_unix|seat|Removed session|Received disconnect|New session)
+  </exclude>
 </filter>
 
 <match auth>

--- a/site-cookbooks/fluentd-custom/files/default/forwarder_consul.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_consul.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   path /var/log/supervisor/consul.log
   pos_file /var/log/td-agent/consul.pos
   format /^(    (?<time>[0-9/]+ [0-9:]+) (?<message>.*$)|(?<message>.*))/
@@ -16,7 +16,11 @@
 
 <filter consul>
   @type grep
-  exclude1 message (raft|memberlist|serf|Synced|Adding|Removing|consul\.fsm: snapshot created|session shutdown)
+
+  <exclude>
+    key message
+    pattern (raft|memberlist|serf|Synced|Adding|Removing|consul\.fsm: snapshot created|session shutdown)
+  </exclude>
 </filter>
 
 <match consul>

--- a/site-cookbooks/fluentd-custom/files/default/forwarder_cron-apt.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_cron-apt.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   path /var/log/cron-apt/log
   pos_file /var/log/td-agent/cron-apt.pos
   format none

--- a/site-cookbooks/fluentd-custom/files/default/forwarder_monit.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_monit.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   path /var/log/monit.log
   pos_file /var/log/td-agent/monit.pos
   format none

--- a/site-cookbooks/fluentd-custom/files/default/forwarder_nginx.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_nginx.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   path /var/log/nginx/*access.log
   pos_file /var/log/td-agent/nginx_logs.pos
   format ltsv

--- a/site-cookbooks/fluentd-custom/files/default/forwarder_td-agent.conf
+++ b/site-cookbooks/fluentd-custom/files/default/forwarder_td-agent.conf
@@ -1,5 +1,5 @@
 <source>
-  type tail
+  @type tail
   path /var/log/td-agent/td-agent.log
   pos_file /var/log/td-agent/td-agent.pos
   format none


### PR DESCRIPTION
This pull request will cover `td-agent`'s broken backward compatibility.

- Change `type` to `@type`
- Change `${host}` to `${hostname}`
- Use `exclude` section, instead of `exclude_n_`